### PR TITLE
Remove database name specific details from schema

### DIFF
--- a/data/schema.txt
+++ b/data/schema.txt
@@ -1,4 +1,4 @@
--- MySQL dump 10.13  Distrib 5.5.32, for debian-linux-gnu (x86_64)
+-- MySQL dump 10.13  Distrib 5.5.38, for debian-linux-gnu (x86_64)
 --
 -- Host: mcs11    Database: npgqct
 -- ------------------------------------------------------
@@ -14,14 +14,6 @@
 /*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
-
---
--- Current Database: `npgqct`
---
-
-CREATE DATABASE /*!32312 IF NOT EXISTS*/ `npgqct` /*!40100 DEFAULT CHARACTER SET latin1 */;
-
-USE `npgqct`;
 
 --
 -- Table structure for table `adapter`
@@ -1476,4 +1468,4 @@ CREATE TABLE `verify_bam_id` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2014-08-08 15:18:09
+-- Dump completed on 2014-08-14 10:03:21


### PR DESCRIPTION
which caused tests on some configurations to fail and which were spuriously
added by use of "--database npgqct" instead of plain "npgqct" with mysqldump
command.
