### PR TITLE
amend statements for import of bcviz libs

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
+ - following restructuring of bcviz, amend statements for import of bcviz libraries
+
 release 57.8.1
  - add temporary file name option to bamtofastq command
 

--- a/npg_qc_viewer/root/static/scripts/main.js
+++ b/npg_qc_viewer/root/static/scripts/main.js
@@ -4,9 +4,9 @@ require.config({
     paths: {
         jquery: 'bower_components/jquery/jquery',
         d3: 'bower_components/d3/d3.min',
-        insert_size_lib: 'bower_components/bcviz/js/src/insertSizeHistogram',
-        adapter_lib: 'bower_components/bcviz/js/src/adapter',
-        mismatch_lib: 'bower_components/bcviz/js/src/mismatch',
+        insert_size_lib: 'bower_components/bcviz/src/qcjson/insertSizeHistogram',
+        adapter_lib: 'bower_components/bcviz/src/qcjson/adapter',
+        mismatch_lib: 'bower_components/bcviz/src/qcjson/mismatch',
     },
     shim: {
         d3: {


### PR DESCRIPTION
This version requires the latest version of bcviz, which is still in devel branch. npg_qc_viewer/README describes how to do this without changing the version of bcviz in the bower.json file