### PR TITLE
Cope with config file (instead of code) based config of npg_tracking

### DIFF
--- a/t/60-autoqc-autoqc.t
+++ b/t/60-autoqc-autoqc.t
@@ -14,6 +14,7 @@ use File::Spec;
 use File::Spec::Functions qw(catfile);
 use Cwd;
 use File::Temp qw/tempdir/;
+local $ENV{'HOME'} = q[t/data];
 
 use_ok ('npg_qc::autoqc::autoqc');
 

--- a/t/60-autoqc-qc_store.t
+++ b/t/60-autoqc-qc_store.t
@@ -5,11 +5,15 @@ use Test::Exception;
 use Test::Warn;
 use File::Temp qw/tempdir/;
 
+local $ENV{'HOME'};
 use npg_testing::db;
 use npg_qc::autoqc::qc_store::options qw/$ALL $LANES $PLEXES/;
 use npg_qc::autoqc::qc_store::query;
 
-BEGIN { use_ok 'npg_qc::autoqc::qc_store' };
+BEGIN { 
+  $ENV{'HOME'} = q[t/data];
+  use_ok 'npg_qc::autoqc::qc_store'
+};
 
 my $schema = npg_testing::db->create_test_db(q{npg_qc::Schema},q[t/data/fixtures]);
 

--- a/t/60-autoqc-results-collection.t
+++ b/t/60-autoqc-results-collection.t
@@ -6,6 +6,7 @@ use Test::Warn;
 use Test::Deep;
 use File::Temp qw/tempdir/;
 
+local $ENV{'HOME'} = q[t/data];
 use npg_qc::autoqc::results::qX_yield;
 use npg_qc::autoqc::results::insert_size;
 use npg_qc::autoqc::results::split_stats;

--- a/t/data/.npg/npg_tracking
+++ b/t/data/.npg/npg_tracking
@@ -1,0 +1,10 @@
+#!/software/bin/env perl
+my $VAR1 = {
+  'staging_areas' => {
+    'indexes' => [18 .. 32, 34 .. 47, 49 .. 55],
+    'prefix' => '/nfs/sf'
+  },
+  'repository' => {
+    'root' => '/lustre/scratch109/srpipe/'
+  }
+}


### PR DESCRIPTION
by providing npg_tracking config in test via HOME directory env var
reset so that paths in tests match those expected

https://github.com/wtsi-npg/npg_tracking/pull/254