### PR TITLE
use network path instead of a local path for ref repository dependant path

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -227,6 +227,7 @@ my $extended_requires = {
                 'npg_tracking::illumina::run::folder'      => 0,
                 'npg_tracking::illumina::run::short_info'  => 0,
                 'npg_tracking::illumina::run::long_info'   => 0,
+                'npg_tracking::util::abs_path'             => 0,
                 'npg_tracking::util::types'                => 0,
                 'st::api::base'                            => 0,
                 'st::api::lims'                            => 0,

--- a/lib/npg_qc/autoqc/checks/gc_fraction.pm
+++ b/lib/npg_qc/autoqc/checks/gc_fraction.pm
@@ -2,7 +2,6 @@
 # Author:        Marina Gourtovaia mg8@sanger.ac.uk
 # Created:       3 February 2010
 #
-#
 
 package npg_qc::autoqc::checks::gc_fraction;
 
@@ -12,10 +11,10 @@ use Moose;
 use Carp;
 use English qw(-no_match_vars);
 use Readonly;
-use Cwd qw(cwd abs_path);
 use File::Spec::Functions qw(catfile);
 use File::Basename;
 
+use npg_tracking::util::abs_path qw(abs_path);
 use npg_common::fastqcheck;
 use npg_common::sequence::reference::base_count;
 
@@ -215,11 +214,11 @@ __END__
 
 =item Moose
 
-=item Cwd
-
 =item File::Spec::Functions
 
 =item File::Basename
+
+=item npg_tracking::util::abs_path
 
 =item npg_tracking::data::reference::find
 

--- a/lib/npg_qc/autoqc/checks/ref_match.pm
+++ b/lib/npg_qc/autoqc/checks/ref_match.pm
@@ -10,12 +10,12 @@ use Carp;
 use English qw(-no_match_vars);
 use File::Basename qw(fileparse);
 use File::Spec::Functions qw(catfile);
-use Cwd 'abs_path';
 use DateTime;
 use Moose;
 use List::Util qw(shuffle);
 use Readonly;
 
+use npg_tracking::util::abs_path qw(abs_path);
 use npg_common::extractor::fastq qw/generate_equally_spaced_reads split_reads/;
 extends 'npg_qc::autoqc::checks::check';
 with    qw/npg_tracking::data::reference::list

--- a/lib/npg_qc/autoqc/checks/sequence_error.pm
+++ b/lib/npg_qc/autoqc/checks/sequence_error.pm
@@ -13,7 +13,6 @@ use Carp;
 use English qw(-no_match_vars);
 use File::Basename;
 use File::Spec::Functions qw(catfile);
-use Cwd qw(cwd abs_path);
 
 use npg_common::extractor::fastq qw(generate_equally_spaced_reads);
 use npg_common::Alignment;
@@ -696,8 +695,6 @@ npg_qc::autoqc::checks::sequence_error
 =item File::Basename
 
 =item File::Spec::Functions qw(catfile)
-
-=item Cwd qw(cwd abs_path)
 
 =item PDL
 


### PR DESCRIPTION
Depends on https://github.com/wtsi-npg/npg_tracking/pull/265
Ensures that local path is not captures in the autoqc results objects.