### PR TITLE
filter 'The client/server socket connection has been renewed' string …

### DIFF
--- a/bin/gtck_extract_fluidigm_data_from_irods.sh
+++ b/bin/gtck_extract_fluidigm_data_from_irods.sh
@@ -28,7 +28,7 @@ do
     if [ -e "${infile}" ]
     then
       printf "================\nProcessing plex list %s, output to %s.tsv\n===============\n" "${infile}" "${outfile_base}"
-      (irodsEnvFile=$HOME/.irods/.irodsEnv-${zone}_gtck baton-get --avu --unbuffered) < "${infile}" | reformat_fluidigm_snp26_results_irods.pl -s 2> "${outfile_base}.err" > "${outfile_base}.tsv"
+      (irodsEnvFile=$HOME/.irods/.irodsEnv-${zone}_gtck baton-get --avu --unbuffered) < "${infile}" | grep -v '^The client/server socket connection has been renewed$' | reformat_fluidigm_snp26_results_irods.pl -s 2> "${outfile_base}.err" > "${outfile_base}.tsv"
       printf "================\nProcessed plex list %s\n===============\n" "${infile}"
     else
       printf "================\nFailed to find expected plex list %s, skipping\n===============\n" "${infile}"

--- a/bin/gtck_install_to_repos.sh
+++ b/bin/gtck_install_to_repos.sh
@@ -2,7 +2,7 @@
 
 # $VERSION = '0';
 
-GTCK_REPOS_ROOT="${GTCK_REPOS_ROOT:-'/nfs/srpipe_references/genotypes /lustre/scratch109/srpipe/genotypes /lustre/scratch110/srpipe/genotypes'}"
+GTCK_REPOS_ROOT="${GTCK_REPOS_ROOT:-/nfs/srpipe_references/genotypes /lustre/scratch109/srpipe/genotypes /lustre/scratch110/srpipe/genotypes}"
 
 if [[ ! -e latest_combined_file.txt ]]
 then


### PR DESCRIPTION
…from baton-get output to avoid invalid JSON input to the downstream reformat_fluidigm_snp26_results_irods.pl script
Correct syntax of line specifying the default value for install target directories (GTCK_REPOS_ROOT)