### PR TITLE
genotype check data extraction scripts, iRODS errors

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
+ - genotype check data extraction scripts - updated scripts to fail more readily
+    and informatively when an iRODS error occurs
+
 release 59.0
  - SeqQC 
    - remove ajax proxy controller

--- a/bin/gtck_extract_fluidigm_data_from_irods.sh
+++ b/bin/gtck_extract_fluidigm_data_from_irods.sh
@@ -1,5 +1,8 @@
 #!/usr/local/bin/bash
 
+# Exit on error
+set -o pipefail
+
 # $VERSION = '0';
 
 GTCK_IRODS_ZONE="${GTCK_IRODS_ZONE:-seq}"
@@ -30,7 +33,14 @@ do
     if [ -e "${infile}" ]
     then
       printf "================\nProcessing plex list %s, output to %s.tsv\n===============\n" "${infile}" "${outfile_base}"
-      (irodsEnvFile=$HOME/.irods/.irodsEnv-${zone}_gtck baton-get --avu --unbuffered) < "${infile}" | grep -v '^The client/server socket connection has been renewed$' | reformat_fluidigm_snp26_results_irods.pl -s 2> "${outfile_base}.err" > "${outfile_base}.tsv"
+      (irodsEnvFile=$HOME/.irods/.irodsEnv-${zone}_gtck baton-get --avu --unbuffered --silent) < "${infile}" | grep -v '^The client/server socket connection has been renewed$' | reformat_fluidigm_snp26_results_irods.pl -s 2> "${outfile_base}.err" > "${outfile_base}.tsv"
+
+      if [ $? -ne 0 ]
+      then
+        printf "\n**** ERROR: failed to extract and reformat data for qc_set ${qc_set} - see %s/${outfile_base}.err for more detailed information\n\n" `pwd`
+        exit -2
+      fi
+
       printf "================\nProcessed plex list %s\n===============\n" "${infile}"
     else
       printf "================\nFailed to find expected plex list %s, skipping\n===============\n" "${infile}"

--- a/bin/gtck_genplexlist.sh
+++ b/bin/gtck_genplexlist.sh
@@ -1,5 +1,7 @@
 #!/usr/local/bin/bash
 
+set -o pipefail
+
 # $VERSION = '0';
 
 GTCK_IRODS_ZONE="${GTCK_IRODS_ZONE:-seq}"
@@ -13,6 +15,13 @@ do
   do
     printf "Generating data_object list for fluidigm_plex = %s\n" ${qc_set}
     jq -n "{avus: [{attribute: \"fluidigm_plex\", value: \"${qc_set}\"}]}" | (irodsEnvFile=$HOME/.irods/.irodsEnv-${zone}_gtck baton-metaquery --zone ${zone} --unbuffered) | jq . | egrep -v "^\[|\]$" | sed -e "s/^  \},$/  \}/" > fluidigm_${qc_set}_${zone}_baton_plex_list_${dttag}.txt
+
+    if [ $? -ne 0 ]
+    then
+      printf "\n**** ERROR: failed to create plex list for qc_set ${qc_set}\n\n"
+      exit -1
+    fi
+
   done
 done
 

--- a/bin/gtck_refresh_check_data.sh
+++ b/bin/gtck_refresh_check_data.sh
@@ -1,5 +1,8 @@
 #!/usr/local/bin/bash
 
+# Exit on error
+set -e -o pipefail
+
 # $VERSION = '0';
 
 if [[ -e latest_plex_list.txt ]] && [[ -e latest_combined_file.txt ]] && ! cmp -s latest_plex_list.txt latest_combined_file.txt

--- a/bin/reformat_fluidigm_snp26_results_irods.pl
+++ b/bin/reformat_fluidigm_snp26_results_irods.pl
@@ -13,6 +13,8 @@ Readonly::Scalar my $FLUIDIGM_RESULT_RSNAME_COL => 1;
 Readonly::Scalar my $FLUIDIGM_RESULT_SAMPLE_NAME_COL => 4;
 Readonly::Scalar my $FLUIDIGM_RESULT_CALL_COL => 9;
 
+Readonly::Scalar my $MAX_FATAL_ERRS => 64;
+
 my %opts;
 getopts('qshn:', \%opts);
 
@@ -115,12 +117,26 @@ my %calls = (
   rs999072 => {strand => q[+], call => q[NN], qc22 => q[N], qc26 => q[N], },
 );
 
+my $errexit_count = 0;
 my $sample_name = q[];
 
 while(<>) {
   chomp;
 
   my $h = from_json($_);
+
+  if($h->{error} or $errexit_count) {
+    # any error reported in the input is fatal, but report the first $MAX_FATAL_ERRS occurrences, then just finish
+    #  reading the input (to avoid potential "broken pipe" upset to an iRODS client supplying the input), then croak
+    if($h->{error}) {
+      if(++$errexit_count < $MAX_FATAL_ERRS) { # fatal, but not right away
+        carp q[error in JSON input; code: ], $h->{error}->{code}, q[; message: ], $h->{error}->{message};
+      }
+    }
+
+    next;
+  }
+
   my $do_name = sprintf q[%s/%s], (defined $h->{collection}? $h->{collection}: q[COLL_UNSPECIFIED]), (defined $h->{data_object}? $h->{data_object}: q[DATAOBJ_UNSPECIFIED]);
 
   my @avu_sn = (grep { $_->{attribute} eq q[sample]; } @{$h->{avus}});
@@ -164,10 +180,9 @@ while(<>) {
   init_calls(\%calls);
 }
 
-# flush out calls for last sample
-  if($sample_name) {
-    dump_results(\%calls, $sample_name);
-  }
+if($errexit_count) { 
+  croak qq[Maximum fatal errors (], $MAX_FATAL_ERRS , q[) detected, exiting];
+}
 
 sub dump_results {
   my ($calls, $sn) = @_;

--- a/bin/reformat_fluidigm_snp26_results_irods.pl
+++ b/bin/reformat_fluidigm_snp26_results_irods.pl
@@ -180,8 +180,8 @@ while(<>) {
   init_calls(\%calls);
 }
 
-if($errexit_count) { 
-  croak qq[Maximum fatal errors (], $MAX_FATAL_ERRS , q[) detected, exiting];
+if($errexit_count) {
+  croak q[Maximum fatal errors (], $MAX_FATAL_ERRS , q[) detected, exiting];
 }
 
 sub dump_results {


### PR DESCRIPTION
updated scripts to fail more readily and informatively when an iRODS error occurs.

Used 'set -e' in the top level gtck_refresh_data.sh script and 'set -o pipefail' with explicit checks for error return in (bash) subscripts. If the reformat_fluidigm_snp26_results_irods.pl perl script sees the "error" attribute in its incoming JSON data stream from baton-get, it reports the first 64 occurrences then croaks after reading the full input stream to avoid a potential blizzard of "broken pipe" errors from an iRODS client supplying the data. Used the '--silent' flag for baton-get since it otherwise replicates to stderr the content of error messages in its JSON output (which will be reported by the reformat_fluidigm_snp26_results_irods.pl script).