### PR TITLE
Bower force latests when in conflict

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
+ - SeqQC
+   - Using --force-latest for bower install deps during Build
+
 release 61.0
  - using test matrix with node 4.4.2 and 0.12.9 for travis
  - help page for manual qc

--- a/npg_qc_viewer/Build.PL
+++ b/npg_qc_viewer/Build.PL
@@ -15,7 +15,7 @@ my $class = npg_tracking::util::build->subclass(code => <<'EOC');
       if (which('node') and which('bower')) {
         warn "Checking/fetching javascript dependencies\n";
       
-        my $result = system 'bower install';
+        my $result = system 'bower install --force-latest';
         if ($result) {
           die 'Fail to install bower javascript dependencies';
         }


### PR DESCRIPTION
Force latest version when finding conflicts with packages versions. Conflict may arise when updating a previously installed stack.