### PR TITLE
introduce regresion to default mysql until fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ env:
     - TRAVIS_NODE_VERSION="4.4.2"
 
 before_install:
- - ./.travis/before_install_mysql57.sh
  - ./.travis/before_install.sh
 install:
  - ./.travis/install.sh


### PR DESCRIPTION
Recent release of mysql (5.7.14) breaks our builds. Until version can be fixed to 5.7.13 use default travis mysql to keep CI working