### PR TITLE
Made building the iRODS handle of npg_qc::autoqc::checks::genotype lazy

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -261,6 +261,7 @@ my $extended_requires = {
                 'st::api::base'                            => 0,
                 'st::api::lims'                            => 0,
                 'WTSI::DNAP::Warehouse::Schema'            => 0,
+                'WTSI::NPG::iRODS'                         => 0,
 };
 
 my $build_requires = {

--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
+ - make building the iRODS handle of npg_qc::autoqc::checks::genotype
+   lazy to avoid calling baton until required at runtime
  - translation from a database composition representation to the
      npg_tracking::glossary::composition type object
  - db query for compisition-based tables should include a condition

--- a/lib/npg_qc/autoqc/checks/genotype.pm
+++ b/lib/npg_qc/autoqc/checks/genotype.pm
@@ -26,9 +26,12 @@ has 'irods' =>
   (is       => 'ro',
    isa      => 'WTSI::NPG::iRODS',
    required => 1,
-   default  => sub {
-       return WTSI::NPG::iRODS->new;
-   },);
+   lazy     => 1,
+   builder  => '_build_irods',);
+
+sub _build_irods {
+  return WTSI::NPG::iRODS->new;
+};
 
 Readonly::Scalar our $HUMAN_REFERENCES_DIR => q[Homo_sapiens];
 Readonly::Scalar my $GENOTYPE_DATA => 'sgd';


### PR DESCRIPTION
Made building the iRODS handle of npg_qc::autoqc::checks::genotype lazy to avoid calling baton until required at runtime.

Added WTSI::NPG::iRODS to Build.PL extended_requires.