### PR TITLE
Can run speedup

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -262,6 +262,7 @@ my $extended_requires = {
                 'st::api::lims'                            => 0,
                 'WTSI::DNAP::Warehouse::Schema'            => 0,
                 'WTSI::NPG::iRODS'                         => 0,
+                'WTSI::NPG::iRODS::DataObject'             => 0,
 };
 
 my $build_requires = {

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
+ - genotype check: speed up pipeline job submission for deeply plexed lanes
+   by moving calls that involde access to reference repository out of the
+   can_run method
+
 release 62.8
  - tag_sniff modified clip and revcomp options to handle split tags
  - Sort results for merged genotypes as well - to avoid out of order failure.

--- a/Changes
+++ b/Changes
@@ -1,8 +1,9 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
- - genotype check: speed up pipeline job submission for deeply plexed lanes
-   by moving calls that involde access to reference repository out of the
-   can_run method
+ - genotype, verify_bam_id, rna_seqc checks:
+     speed up pipeline job submission for deeply plexed lanes
+     by moving calls that involde access to reference repository out of the
+     can_run method
 
 release 62.8
  - tag_sniff modified clip and revcomp options to handle split tags

--- a/lib/npg_qc/autoqc/checks/genotype.pm
+++ b/lib/npg_qc/autoqc/checks/genotype.pm
@@ -5,14 +5,16 @@ use namespace::autoclean;
 use Carp;
 use File::Basename;
 use File::Spec::Functions qw(catfile catdir);
-use List::MoreUtils qw { any };
+use List::MoreUtils qw(any);
 use File::Slurp;
 use JSON;
-use npg_qc::utils::bam_genotype;
-use npg_qc::autoqc::types;
 use Readonly;
 use FindBin qw($Bin);
 use Try::Tiny;
+
+use npg_qc::utils::bam_genotype;
+use npg_qc::autoqc::types;
+use WTSI::NPG::iRODS;
 use WTSI::NPG::iRODS::DataObject;
 
 extends qw(npg_qc::autoqc::checks::check);
@@ -22,18 +24,8 @@ with qw(npg_tracking::data::reference::find
 
 our $VERSION = '0';
 
-has 'irods' =>
-  (is       => 'ro',
-   isa      => 'WTSI::NPG::iRODS',
-   required => 1,
-   lazy     => 1,
-   builder  => '_build_irods',);
-
-sub _build_irods {
-  return WTSI::NPG::iRODS->new;
-};
-
-Readonly::Scalar our $HUMAN_REFERENCES_DIR => q[Homo_sapiens];
+Readonly::Scalar my  $HUMAN                => q[Homo_sapiens];
+Readonly::Scalar our $HUMAN_REFERENCES_DIR => $HUMAN;
 Readonly::Scalar my $GENOTYPE_DATA => 'sgd';
 Readonly::Scalar my $SAMTOOLS_NAME => q[samtools_irods];
 Readonly::Scalar my $SAMTOOLS_EXTRACT_REGIONS_NAME => q[samtools1];
@@ -65,6 +57,17 @@ sub _build_human_references_repository {
 	my $self = shift;
 	return catdir($self->ref_repository, $HUMAN_REFERENCES_DIR);
 }
+
+has 'irods' =>(
+   is       => 'ro',
+   isa      => 'WTSI::NPG::iRODS',
+   required => 1,
+   lazy     => 1,
+   builder  => '_build_irods',
+);
+sub _build_irods {
+  return WTSI::NPG::iRODS->new();
+};
 
 # you can override the executable name. May be useful for variants like "samtools_irods"
 has 'samtools_name' => (
@@ -457,8 +460,6 @@ sub _build_bam_genotype {
 override 'can_run' => sub {
 	my $self = shift;
 
-	# make sure that a sample name has been supplied and that the bam file is aligned with one of the recognised human references
-
 	if(!defined $self->sample_name) {
 		$self->result->add_comment('No sample name specified');
 		return 0;
@@ -469,17 +470,13 @@ override 'can_run' => sub {
 		return 0;
 	}
 
-	if(!defined($self->reference_fasta) || (! -r $self->reference_fasta)) {
-		$self->result->add_comment('Reference genome missing or unreadable');
+  my $ref = $self->lims->reference_genome;
+  if($ref && $ref !~ /\A$HUMAN/smx) {
+    $self->result->add_comment("Non-human reference genome '$ref'");
 		return 0;
-	}
+  }
 
-	if(! any { $_ =~ $self->reference_fasta; } (keys %{$self->_ref_to_snppos_suffix_map})) {
-		$self->result->add_comment('Specified reference genome may be non-human');
-		return 0;
-	}
-
-	return 1;
+  return 1;
 };
 
 override 'execute' => sub {
@@ -491,7 +488,16 @@ override 'execute' => sub {
 		return 1;
 	}
 
-# run check
+  if(!defined($self->reference_fasta) || (! -r $self->reference_fasta)) {
+		croak 'Reference genome missing or unreadable';
+	}
+
+  # make sure that the bam file is aligned with one of the recognised human references
+	if(! any { $_ =~ $self->reference_fasta; } (keys %{$self->_ref_to_snppos_suffix_map})) {
+		croak 'Specified reference genome may be non-human';
+	}
+
+  # run check
 	my $gt_check_cmd = sprintf
 			q{set -o pipefail && printf "%s" | %s %s %s | %s %s %s},
 			$self->tsv_genotype,
@@ -697,7 +703,35 @@ npg_qc::autoqc::checks::genotype - compare genotype from bam with Sequenom QC re
 
 =over
 
+=item Moose
+
 =item namespace::autoclean
+
+=item Carp
+
+=item File::Basename
+
+=item File::Spec::Functions
+
+=item List::MoreUtils
+
+=item File::Slurp
+
+=item JSON
+
+=item Readonly
+
+=item FindBin
+
+=item Try::Tiny
+
+=item npg_tracking::data::reference::find
+
+=item WTSI::NPG::iRODS
+
+=item WTSI::NPG::iRODS::DataObject
+
+=item npg_common::roles::software_location
 
 =back
 
@@ -707,7 +741,7 @@ Kevin Lewis, kl2
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2015 GRL
+Copyright (C) 2017 GRL
 
     This file is part of NPG.
 

--- a/lib/npg_qc/autoqc/checks/verify_bam_id.pm
+++ b/lib/npg_qc/autoqc/checks/verify_bam_id.pm
@@ -63,13 +63,6 @@ override 'can_run' => sub {
     return 0;
   }
 
-  # we want to run iff there is a VCF file for this organism/strain/bait
-
-  if (!$self->snv_file) {
-    $self->result->add_comment(q(Can't find VCF file));
-    return 0;
-  }
-
   if (!$self->lims->sample_name) { # sample_name() only returns non empty value iff there is a single sample_name
     $self->result->add_comment(q(Can only run on single sample));
     return 0;
@@ -80,6 +73,11 @@ override 'can_run' => sub {
 
 override 'execute' => sub {
   my ($self) = @_;
+
+  if (!$self->snv_file) {
+    croak q(Can't find snv file);
+  }
+
   my $outfile = $self->tmp_path . q(/) . basename($self->bam_file);
 
   my $cmd_options =

--- a/t/60-autoqc-checks-genotype.t
+++ b/t/60-autoqc-checks-genotype.t
@@ -21,8 +21,8 @@ my $bt = join q[/], $dir, q[bcftools1];
 local $ENV{PATH} = join q[:], $dir, $ENV{PATH};
 my $data_dir = $dir."/data";
 mkdir($data_dir);
-`cp t/data/autoqc/alignment.bam $data_dir/2_1_1.bam`;
-`echo -n $expected_md5 > $data_dir/2_1_1.bam.md5`;
+`cp t/data/autoqc/alignment.bam $data_dir/2_1.bam`;
+`echo -n $expected_md5 > $data_dir/2_1.bam.md5`;
 
 # create and populate a temporary iRODS collection
 my $irods = WTSI::NPG::iRODS->new;
@@ -34,13 +34,11 @@ $irods->put_collection($data_dir, $irods_tmp_coll);
 $irods_data_coll = $irods_tmp_coll."/data";
 
 {
-    my $r;
-
-    $r = npg_qc::autoqc::checks::genotype->new(
-        id_run => 2,
-        path => $data_dir,
-        position => 1,
-        repository => $ref_repos,
+    my $r = npg_qc::autoqc::checks::genotype->new(
+        id_run      => 2,
+        position    => 1,
+        input_files => ["$data_dir/2_1.bam"],
+        repository  => $ref_repos,
     );
     isa_ok ($r, 'npg_qc::autoqc::checks::genotype');
     lives_ok { $r->result; } 'No error creating result object';
@@ -55,16 +53,15 @@ $irods_data_coll = $irods_tmp_coll."/data";
         repository => $ref_repos, rpt_list => '2:1', path => q[t]); }
       'object via the rpt_list';
 
-    my $irods_path = "irods:".$irods_data_coll."/2_1_1.bam";
+    my $irods_path = 'irods:'.$irods_data_coll.'/2_1.bam';
     $r = npg_qc::autoqc::checks::genotype->new(
-        id_run => 2,
-        input_files => [$irods_path, ],
-        position => 1,
-        repository => $ref_repos,
+        id_run      => 2,
+        position    => 1,
+        input_files => [$irods_path],
+        repository  => $ref_repos,
     );
     is($r->input_files_md5, $expected_md5,
        "iRODS MD5 string matches expected value");
-
 }
 
 # remove temporary iRODS collection

--- a/t/60-autoqc-checks-rna_seqc.t
+++ b/t/60-autoqc-checks-rna_seqc.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use Cwd qw/getcwd abs_path/;
-use Test::More tests => 17;
+use Test::More tests => 16;
 use Test::Exception;
 use File::Temp qw/ tempdir /;
 
@@ -112,8 +112,8 @@ my $repos = getcwd . '/t/data/autoqc/rna_seqc';
         qc_report_dir => q[t/data],
         _annotation_gtf => q[],
         ref_repository => $ref_repos_dir,);
-    lives_ok { $check->execute } 'execution ok for no annotation file';
-    like ($check->result->comments, qr/No GTF annotation available/, 'comment when annotation file is not available');
+    throws_ok { $check->execute } qr/No GTF annotation available/,
+      'error in execution for no annotation file';
 
     open $fh,  q[>], $si;
     print $fh qq[cat $repos/data/17550_1#1.bam\n];

--- a/t/60-autoqc-checks-verify_bam_id.t
+++ b/t/60-autoqc-checks-verify_bam_id.t
@@ -2,7 +2,7 @@ use strict;
 use warnings;
 use Cwd;
 use File::Temp qw/ tempdir /;
-use Test::More tests => 50;
+use Test::More tests => 49;
 use Test::Exception;
 
 my $repos = cwd . '/t/data/autoqc';
@@ -101,7 +101,8 @@ my $dir = tempdir(CLEANUP => 1);
   is($r->lims->library_type, 'Standard', 'Standard library type returned OK');
   is($r->alignments_in_bam, 1, 'Alignments in bam');
   is($r->snv_path, undef, 'snv path is not set');
-  is($r->can_run, 0, 'Not done if library_type is Standard and bam file is aligned BUT there is no VCF file');
+  throws_ok {$r->execute()} qr/Can't find snv file/,
+    'Not done if library_type is Standard and bam file is aligned BUT there is no VCF file';
 }
 
 {
@@ -117,7 +118,6 @@ my $dir = tempdir(CLEANUP => 1);
   is($r->lims->reference_genome, 'Anopheles_gambiae (PEST)' , 'Has a reference genome');    
   my $snv_path = join '/', cwd, 't/data/autoqc/population_snv_with_vcf/Anopheles_gambiae/default/Standard/PEST';
   is($r->snv_path, $snv_path, 'snv path is set correctly');
-  is($r->can_run, 1, 'Done if library_type is Standard and bam file is aligned and there is a VCF file');
 }
 
 {


### PR DESCRIPTION
can_run on individual check objects is called by the pipeline when deciding whether to create a job for a particular entity. In three checks live accesses to a reference repository are made withing this method. For a run with 1500 plexes in each lane that results in 1500x8x3 lookups, which significantly slows down LSF job submission. 

See also https://github.com/wtsi-npg/npg_seq_pipeline/pull/212