### PR TITLE
change behaviour of build regarding node tools

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
+ - SeqQC
+   - Build will fail if no node, npm or bower are available in path
+
 release 62.9
  - fix for GD image generation test in response to a change in constructor
    behaviour in GD.pm

--- a/npg_qc_viewer/Build.PL
+++ b/npg_qc_viewer/Build.PL
@@ -28,7 +28,7 @@ my $class = npg_tracking::util::build->subclass(code => <<'EOC');
         }
       } else {
         warn "To install javascript dependencies, node and bower should be on the path;\n";
-        warn "javascript dependencies not installed.\n";
+        die 'Javascript dependencies cannot be installed';
       }
     }
 


### PR DESCRIPTION
 - build will die if node or bower or npm are not available in the path