### PR TITLE
Autoqc dbloader refactoring

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ iLIST OF CHANGES FOR NPG-QC PACKAGE
 
  - db composition creation via a factory method autoqc
  - db loader - unused 'update' option removed
+ - saving a component with subset attribute value 'all' errors
 
 release 63.0
  - update script for deleting autoqc database results so that it

--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
-LIST OF CHANGES FOR NPG-QC PACKAGE
+iLIST OF CHANGES FOR NPG-QC PACKAGE
+
+ - db composition creation via a factory method autoqc
+ - db loader - unused 'update' option removed
 
 release 63.0
  - update script for deleting autoqc database results so that it

--- a/Changes
+++ b/Changes
@@ -1,8 +1,10 @@
 iLIST OF CHANGES FOR NPG-QC PACKAGE
 
- - db composition creation via a factory method autoqc
- - db loader - unused 'update' option removed
- - saving a component with subset attribute value 'all' errors
+ - db composition creation via a factory method
+ - db autoqc loader - unused 'update' option removed
+ - db autoqc loader - will retry a transaction that failed because
+     a db lock could not be aquired
+ - saving a component with subset attribute value 'all' gives an error
 
 release 63.0
  - update script for deleting autoqc database results so that it

--- a/MANIFEST
+++ b/MANIFEST
@@ -416,6 +416,7 @@ t/50-schema-result-MqcOutcomeEnt.t
 t/50-schema-result-MqcOutcomeHist.t
 t/50-schema-result-VerifyBamId.t
 t/50-schema-result-SamtoolsStats.t
+t/50-schema-result-SeqComposition.t
 t/50-schema-result-SequenceSummary.t
 t/50-schema-resultset.t
 t/50-schema-resultset-MqcOutcomeEnt.t

--- a/lib/npg_qc/autoqc/db_loader.pm
+++ b/lib/npg_qc/autoqc/db_loader.pm
@@ -167,19 +167,14 @@ sub _values2db {
 
   my $result_class = $rs->result_class;
   $self->_exclude_nondb_attrs($values, $result_class->columns());
-
-  my $transaction = sub {
-    $rs->deflate_unique_key_components($values);
-    my $row = $rs->find_or_new($values);
-    if ($result_class->has_column('iscurrent') && $row->in_storage) {
-      $row->update({'iscurrent' => 0});
-      $row = $rs->new_result($values);
-    }
-    # We need to convert non-scalar values (hashes or arrays) to scalars
-    $row->set_inflated_columns($values)->insert_or_update();
-  };
-
-  $self->schema->txn_do($transaction);
+  $rs->deflate_unique_key_components($values);
+  my $row = $rs->find_or_new($values);
+  if ($result_class->has_column('iscurrent') && $row->in_storage) {
+    $row->update({'iscurrent' => 0});
+    $row = $rs->new_result($values);
+  }
+  # We need to convert non-scalar values (hashes or arrays) to scalars
+  $row->set_inflated_columns($values)->insert_or_update();
 
   return;
 }

--- a/lib/npg_qc/autoqc/db_loader.pm
+++ b/lib/npg_qc/autoqc/db_loader.pm
@@ -19,7 +19,7 @@ with qw/MooseX::Getopt/;
 our $VERSION = '0';
 
 Readonly::Scalar my $CLASS_FIELD             => q[__CLASS__];
-Readonly::Scalar my $SEQ_COMPISITION_PK_NAME => q[id_seq_composition];
+Readonly::Scalar my $SEQ_COMPOSITION_PK_NAME => q[id_seq_composition];
 
 has 'path'   =>  ( is          => 'ro',
                    isa         => 'ArrayRef[Str]',
@@ -143,8 +143,8 @@ sub _json2db{
           my $rs  = $self->schema->resultset($dbix_class_name);
           my $related_composition = $rs->find_or_create_seq_composition($obj->composition());
           if ($related_composition) {
-            $values->{$SEQ_COMPISITION_PK_NAME} =
-              $related_composition->$SEQ_COMPISITION_PK_NAME();
+            $values->{$SEQ_COMPOSITION_PK_NAME} =
+              $related_composition->$SEQ_COMPOSITION_PK_NAME();
           }
           $self->_values2db($rs, $values);
           $count++;

--- a/lib/npg_qc/autoqc/db_loader.pm
+++ b/lib/npg_qc/autoqc/db_loader.pm
@@ -18,7 +18,8 @@ with qw/MooseX::Getopt/;
 
 our $VERSION = '0';
 
-Readonly::Scalar my $CLASS_FIELD => q[__CLASS__];
+Readonly::Scalar my $CLASS_FIELD             => q[__CLASS__];
+Readonly::Scalar my $SEQ_COMPISITION_PK_NAME => q[id_seq_composition];
 
 has 'path'   =>  ( is          => 'ro',
                    isa         => 'ArrayRef[Str]',
@@ -42,12 +43,6 @@ has 'check'   => ( is          => 'ro',
                    isa         => 'ArrayRef[Str]',
                    required    => 0,
                    default     => sub {[]},
-                 );
-
-has 'update'  => ( is       => 'ro',
-                   isa      => 'Bool',
-                   required => 0,
-                   default  => 1,
                  );
 
 has 'json_file' => ( is          => 'ro',
@@ -130,10 +125,6 @@ sub load{
 sub _json2db{
   my ($self, $json, $json_file) = @_;
 
-  if (!$json) {
-    croak 'JSON string representation of the object is missing';
-  }
-
   my $count = 0;
   try {
     my $values = decode_json($json);
@@ -146,103 +137,51 @@ sub _json2db{
           my $module = 'npg_qc::autoqc::results::' . $class_name;
           load_class($module);
           my $obj = $module->thaw($json);
-
           if ($class_name eq 'bam_flagstats') {
             $values = decode_json($obj->freeze());
           }
-          my $composition_key = 'id_seq_composition';
-          if ( $obj->can('composition') && $obj->can('composition_digest') &&
-              $self->schema->source($dbix_class_name)->has_column($composition_key) ) {
-            $values->{$composition_key} = $self->_ensure_composition_exists($obj);
+          my $rs  = $self->schema->resultset($dbix_class_name);
+          my $related_composition = $rs->find_or_create_seq_composition($obj->composition());
+          if ($related_composition) {
+            $values->{$SEQ_COMPISITION_PK_NAME} =
+              $related_composition->$SEQ_COMPISITION_PK_NAME();
           }
-          # Load the main object
-          $count = $self->_values2db($dbix_class_name, $values);
+          $self->_values2db($rs, $values);
+          $count++;
         }
       }
     }
   } catch {
-    my $j =  $json_file || $json;
-    $self->_log("Attempted to load $j");
-    croak $_;
+    my $e = $_;
+    $self->_log("Attempted to load $json_file, error $e");
+    croak $e;
   };
-  my $m = $count ? 'Loaded' : 'Skipped';
-  $self->_log(join q[ ], $m, $json_file || q[json string]);
+
+  $self->_log(join q[ ], $count ? 'Loaded' : 'Skipped', $json_file);
 
   return $count;
-}
-
-sub _ensure_composition_exists {
-  my ($self, $obj) = @_;
-
-  my $num_components = $obj->composition->num_components;
-  my $composition_row = $self->schema->resultset('SeqComposition')
-    ->find_or_new({ 'digest' => $obj->composition_digest,
-                    'size'   => $num_components, });
-  my $composition_exists = 1;
-  if (!$composition_row->in_storage()) {
-    $composition_row->insert();
-    $composition_exists = 0;
-  }
-  my $pk = $composition_row->id_seq_composition;
-
-  if (!$composition_exists) {
-
-    my $component_rs   = $self->schema->resultset('SeqComponent');
-    my $comcom_rs      = $self->schema->resultset('SeqComponentComposition');
-
-    foreach  my $c ($obj->composition->components_list()) {
-      my $values = decode_json($c->freeze());
-      $values->{'digest'} = $c->digest();
-      my $row = $component_rs->find_or_create($values);
-      # Whether the component existed or not, we have to create a new
-      # composition membership record for it.
-      $values = {
-        'id_seq_composition' => $pk,
-        'id_seq_component'   => $row->id_seq_component,
-        'size'               => $num_components,
-      };
-      $comcom_rs->create($values);
-    }
-  }
-
-  return $pk;
 }
 
 sub _values2db {
-  my ($self, $dbix_class_name, $values) = @_;
+  my ($self, $rs, $values) = @_;
 
-  my $iscurrent_column_name      = 'iscurrent';
-  my $composition_fk_column_name = 'id_seq_composition';
-  my $count = 0;
-  my $rs = $self->schema->resultset($dbix_class_name);
   my $result_class = $rs->result_class;
   $self->_exclude_nondb_attrs($values, $result_class->columns());
 
-  my $found;
-  if ($result_class->has_column($iscurrent_column_name)) {
-    my $fk_value = $values->{$composition_fk_column_name};
-    if ($fk_value) {
-      $rs->search({$composition_fk_column_name => $fk_value})
-         ->update({$iscurrent_column_name => 0});
-    }
-  } else {
+  my $transaction = sub {
     $rs->deflate_unique_key_components($values);
-    $found = $rs->find($values);
-  }
-
-  if ($found) {
-    if ($self->update) {
-      # We need to convert non-scalar values (hashes or arrays) to scalars
-      $found->set_inflated_columns($values)->update();
-      $count++;
+    my $row = $rs->find_or_new($values);
+    if ($result_class->has_column('iscurrent') && $row->in_storage) {
+      $row->update({'iscurrent' => 0});
+      $row = $rs->new_result($values);
     }
-  } else {
-    # See comment above
-    $rs->new_result($values)->set_inflated_columns($values)->insert();
-    $count++;
-  }
+    # We need to convert non-scalar values (hashes or arrays) to scalars
+    $row->set_inflated_columns($values)->insert_or_update();
+  };
 
-  return $count;
+  $self->schema->txn_do($transaction);
+
+  return;
 }
 
 sub _exclude_nondb_attrs {
@@ -352,11 +291,6 @@ npg_qc::autoqc::db_loader
 =head2 verbose
 
   A boolean attribute, switches logging on/off, true by default.
-
-=head2 update
-
-  A boolean attribute, true by default, switches on/off updates of existing
-  results. If false, only new results are inserted.
 
 =head2 schema
 

--- a/lib/npg_qc/autoqc/db_loader.pm
+++ b/lib/npg_qc/autoqc/db_loader.pm
@@ -116,7 +116,8 @@ sub load{
   } catch {
     my $m = "Loading aborted, transaction has rolled back: $_";
     $self->_log($m);
-    if ($m =~ /\ lock/smxi) { # Failure to acquire a lock
+    # Retry only if failed to get a lock
+    if ($m =~ /Deadlock found when trying to get lock/smxi) {
       $self->_log("Will pause for $SLEEP_TIME seconds, then retry");
       sleep $SLEEP_TIME;
       $num_loaded = $self->schema->txn_do($transaction);

--- a/t/50-schema-result-SeqComposition.t
+++ b/t/50-schema-result-SeqComposition.t
@@ -1,0 +1,71 @@
+use strict;
+use warnings;
+use Test::More tests => 2;
+use Moose::Meta::Class;
+use npg_tracking::glossary::composition::factory;
+use npg_tracking::glossary::composition::component::illumina;
+use npg_testing::db;
+
+use_ok('npg_qc::Schema::Result::SeqComposition');
+
+my $schema = Moose::Meta::Class->create_anon_class(
+          roles => [qw/npg_testing::db/])
+          ->new_object({})->create_test_db(q[npg_qc::Schema]);
+
+subtest q[creating new composition from new and existing components] => sub {
+  plan tests => 16;
+
+  my $id_run = 1;
+
+  my $rs_composition = $schema->resultset('SeqComposition');
+  my $rs_component   = $schema->resultset('SeqComponent');
+  my $rs_cc          = $schema->resultset('SeqComponentComposition');
+
+  my @values = (
+    [{id_run => $id_run,position => 2}],
+    [{id_run => $id_run,position => 3}, {id_run => $id_run,position => 2}],
+    [{id_run => $id_run,position => 2,subset=>'phix'}],
+    [{id_run => $id_run,position => 1,tag_index => 22},
+     {id_run => $id_run,position => 1,tag_index => 23},
+     {id_run => $id_run,position => 1,tag_index => 24}],
+    [{id_run => $id_run,position => 1,tag_index => 12},
+     {id_run => $id_run,position => 1,tag_index => 13},
+     {id_run => $id_run,position => 1,tag_index => 14}],
+    [{id_run => $id_run,position => 3,tag_index => 0}],
+    [{id_run => $id_run,position => 1,tag_index => 22,subset => 'human'},
+     {id_run => $id_run,position => 1,tag_index => 24,subset => 'human'}],
+    [{id_run => $id_run,position => 1,tag_index => 25,subset => 'phix'},
+     {id_run => $id_run,position => 1,tag_index => 26,subset => 'phix'}],  
+  );
+
+  foreach my $values_array (@values) {
+
+    my $f = npg_tracking::glossary::composition::factory->new();
+    my @component_ids = ();
+    foreach my $value (@{$values_array}) {
+      my $component = npg_tracking::glossary::composition::component::illumina
+                      ->new($value);
+      $f->add_component($component);
+      my %temp = %{$value};
+      $temp{'digest'} = $component->digest();
+      push @component_ids, $rs_component->find_or_create(\%temp)->id_seq_component();
+    }
+    my $composition = $f->create_composition();
+    my $num_components = $composition->num_components;
+    my $row = $rs_composition->create(
+      {digest => $composition->digest, size => $num_components});
+    my $pk_value= $row->id_seq_composition;
+    foreach my $id (@component_ids) {
+      $rs_cc->create({'size'               => $num_components,
+                      'id_seq_component'   => $id,
+                      'id_seq_composition' => $pk_value,
+                     });
+    }
+
+    my $compisition_from_db = $row->create_composition();
+    isa_ok($compisition_from_db, 'npg_tracking::glossary::composition');
+    ok($compisition_from_db->digest eq $composition->digest(), 'the same composition');
+  }
+};
+
+1;


### PR DESCRIPTION
... because we need a factory method for db-based compositions, which can be used elsewhere (in migration of all autoqc tables to compositions).  Lots of tests as well.