### PR TITLE
use explicit dist in travis yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ perl:
   - "5.16"
   - "5.22-shrplib"
 
+dist:
+  - precise
+
 addons:
   postgresql: "9.3"
 

--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@ LIST OF CHANGES FOR NPG-QC PACKAGE
      position, etc
  - remove superfluous method call from a template
  - remove unused qc_chema property from TransferObjectFactory 
+ - set explicit dist to precise in travis yml
 
 release 63.1
  - label fix for rna_seqc in SeqQC viewer


### PR DESCRIPTION
Because otherwise they will move use by default to trusty

https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming