### PR TITLE
fix resultset constructor

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
  
+ - Cannot have default Moose constructor in derived DBIx classes - fix for
+     custom MqcOutcomeEnt resultset
  - DBIx achema loader script: automatically add npg_qc::Schema::Composition
      role when generating result classes for autoqc tables
  - DBIx classes for autoqc db tables:

--- a/lib/npg_qc/Schema/ResultSet/MqcOutcomeEnt.pm
+++ b/lib/npg_qc/Schema/ResultSet/MqcOutcomeEnt.pm
@@ -1,8 +1,7 @@
 package npg_qc::Schema::ResultSet::MqcOutcomeEnt;
 
 use Moose;
-use MooseX::NonMoose;
-use namespace::autoclean;
+use MooseX::MarkAsMethods autoclean => 1;
 
 extends 'npg_qc::Schema::ResultSet';
 
@@ -29,7 +28,7 @@ sub get_ready_to_report {
   return $rs;
 }
 
-__PACKAGE__->meta->make_immutable;
+__PACKAGE__->meta->make_immutable(inline_constructor => 0);
 
 1;
 __END__
@@ -67,9 +66,7 @@ npg_qc::Schema::ResultSet::MqcOutcomeEnt
 
 =item Moose
 
-=item MooseX::NonMoose
-
-=item namespace::autoclean
+=item MooseX::MarkAsMethods
 
 =item npg_qc::Schema::ResultSet
 
@@ -85,7 +82,7 @@ Jaime Tovar <lt>jmtc@sanger.ac.uk<gt>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2016 GRL Genome Research Limited
+Copyright (C) 2017 GRL Genome Research Limited
 
 This file is part of NPG.
 

--- a/t/50-schema-resultset-MqcOutcomeEnt.t
+++ b/t/50-schema-resultset-MqcOutcomeEnt.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 4;
+use Test::More tests => 5;
 use Test::Exception;
 use Moose::Meta::Class;
 use npg_testing::db;
@@ -18,6 +18,9 @@ my $resultset = $schema->resultset($table);
 while (my $row = $resultset->next) {
   $row->delete;
 }
+ 
+lives_and {is $resultset->search_autoqc({})->count(), 0}
+  'having invoked search_autoqc() method can run count() method';
 
 subtest q[outcomes ready for reporting] => sub {
   plan tests => 15;


### PR DESCRIPTION
Without thi sfix we have the following failure

died: Moose::Exception::SingleParamsToNewMustBeHashRef (Single parameters to new() must be a HASH ref at constructor npg_qc::Schema::ResultSet::MqcOutcomeEnt::new (defined at /nfs/users/nfs_m/mg8/working/npg_qc/blib/lib/npg_qc/Schema/ResultSet/MqcOutcomeEnt.pm line 32) line 11
npg_qc::Schema::ResultSet::MqcOutcomeEnt::new('npg_qc::Schema::ResultSet::MqcOutcomeEnt', 'DBIx::Class::ResultSource::Table=HASH(0x6f082b0)') called at /software/npg/20170908/lib/perl5/DBIx/Class/ResultSet.pm line 3389
DBIx::Class::ResultSet::as_subselect_rs('npg_qc::Schema::ResultSet::MqcOutcomeEnt=HASH(0x7eb4650)') called at /software/npg/20170908/lib/perl5/DBIx/Class/ResultSet.pm line 1766
DBIx::Class::ResultSet::_count_subq_rs('npg_qc::Schema::ResultSet::MqcOutcomeEnt=HASH(0x7eeca00)', 'HASH(0x7eec880)') called at /software/npg/20170908/lib/perl5/DBIx/Class/ResultSet.pm line 1605
DBIx::Class::ResultSet::count('npg_qc::Schema::ResultSet::MqcOutcomeEnt=HASH(0x7eeca00)') called at t/50-schema-resultset-MqcOutcomeEnt.t line 22
