### PR TITLE
change naming of spatial_filter stats files for spatial_filter check

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
  - modified spatial filter qc check to read all run_lane filter.stats files
+ - changed naming of spatial_filter stats files to <run>_<lane>*.spatial_filter.stats
  - upstream_tags qc check - replaced bamindexdecoder with bambi decode
  - dropped ability for qc checks to sub-sample input fastq
      instead run the checks directly off the cached fastq files

--- a/lib/npg_qc/autoqc/checks/spatial_filter.pm
+++ b/lib/npg_qc/autoqc/checks/spatial_filter.pm
@@ -10,7 +10,7 @@ our $VERSION = '0';
 
 override 'execute' => sub {
 	my ($self) = @_;
-  my $filter_stats_file_name_glob = $self->qc_in . q{/} . $self->id_run . '_' . $self->position . q{*.filter.stats};
+  my $filter_stats_file_name_glob = $self->qc_in . q{/} . $self->id_run . '_' . $self->position . q{*.spatial_filter.stats};
   my @filter_stats_files = glob $filter_stats_file_name_glob or
     croak "Cannot find any filter stats files using $filter_stats_file_name_glob";
   $self->result->parse_output(\@filter_stats_files); #read stderr from spatial_filter -a for each sample


### PR DESCRIPTION
change naming of spatial_filter stats files to <run>_<lane>*.spatial_filter.stats for easier identification