### PR TITLE
insert_size and sequence_error checks - explicitly define bwa0_6 aligner

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,6 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
-
+ - insert_size and sequence_error checks - explicitly define bwa0_6 aligner
  - add genotype_call_results_reporter script to report genotype_call
    results to the LIMs
  - tag_metics matches_pf_percent only stored to three decimals places now

--- a/lib/npg_qc/autoqc/checks/insert_size.pm
+++ b/lib/npg_qc/autoqc/checks/insert_size.pm
@@ -25,7 +25,6 @@ with qw(
   npg_tracking::data::reference::find
   npg_common::roles::software_location
        );
-has '+aligner' => (default => 'bwa0_6', is => 'ro');
 
 our $VERSION = '0';
 
@@ -60,7 +59,23 @@ Readonly::Scalar our $RANGE_EXPANSION_COEFF  => 0.25;
 Readonly::Scalar our $MAX_ISIZE_COEFF        => 2;
 Readonly::Scalar our $CHILD_ERROR_SHIFT      => 8;
 
+Readonly::Scalar my  $ALIGNER => 'bwa0_6';
+
 our $_alignment_count = 0; ## no critic (Variables::ProhibitPackageVars)
+
+=head2 aligner
+
+Aligner name, defaults to bwa0_6
+
+=cut
+
+#####
+# Overwrite builder nethod for the aligner attribute defined
+# in the npg_tracking::data::reference::find role
+#
+sub _build_aligner {
+  return $ALIGNER;
+}
 
 =head2 actual_sample_size
 

--- a/lib/npg_qc/autoqc/checks/sequence_error.pm
+++ b/lib/npg_qc/autoqc/checks/sequence_error.pm
@@ -17,7 +17,6 @@ with qw(
   npg_common::roles::SequenceInfo
   npg_common::roles::software_location
 );
-has '+aligner' => (default => 'bwa0_6', is => 'ro');
 
 our $VERSION = '0';
 ## no critic (Documentation::RequirePodAtEnd ProhibitParensWithBuiltins ProhibitStringySplit RequireNumberSeparators)
@@ -34,9 +33,25 @@ Readonly::Scalar our $LOW_RANGE           => 15;
 Readonly::Scalar our $MID_RANGE           => 30;
 Readonly::Scalar our $HIGH_RANGE          => 31;
 
+Readonly::Scalar my  $ALIGNER  => 'bwa0_6';
+
 use PDL::Lite; use PDL::Core qw(pdl); use PDL::Basic qw(yvals);
 Readonly::Scalar our $CIGAR_VALID_CHAR => q(MDINPHS);
 Readonly::Scalar our $NUM_TOP_CIGARS => 5;
+
+=head2 aligner
+
+Aligner name, defaults to bwa0_6
+
+=cut
+
+#####
+# Overwrite builder nethod for the aligner attribute defined
+# in the npg_tracking::data::reference::find role
+#
+sub _build_aligner {
+  return $ALIGNER;
+}
 
 =head2 reference
 

--- a/t/60-autoqc-checks-insert_size.t
+++ b/t/60-autoqc-checks-insert_size.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 61;
+use Test::More tests => 62;
 use Test::Exception;
 use Test::Deep;
 use Perl6::Slurp;
@@ -64,6 +64,7 @@ sub _additional_modules {
                                               repository => $repos, 
                                                    );
   is($qc->can_run, 1, 'check can_run for a paired run');
+  is($qc->aligner, 'bwa0_6', 'default aligner');
 }
 
 {

--- a/t/60-autoqc-checks-sequence_error.t
+++ b/t/60-autoqc-checks-sequence_error.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use File::Copy;
-use Test::More tests => 63;
+use Test::More tests => 64;
 use Test::Exception;
 use Test::Deep;
 use File::Temp qw/ tempdir /;
@@ -173,6 +173,7 @@ use_ok('npg_qc::autoqc::checks::sequence_error');
   is( $error_check->sample_size, 10000, 'default required sample size');
   my @fastq_files = $error_check->get_input_files ();
   is( $fastq_files[0], 't/data/autoqc/090721_IL29_2549/data/2549_2_1.fastq', 'correct first fastq full name');
+  is( $error_check->aligner, 'bwa0_6', 'default aligner');
 }
 
 {


### PR DESCRIPTION
Replaces the code that did not work correctly - it's not possible overwite default for the Moose attribute

Depends on https://github.com/wtsi-npg/npg_tracking/pull/462