### PR TITLE
change spatial_filter check to use input_files attribute

### DIFF
--- a/lib/npg_qc/autoqc/checks/spatial_filter.pm
+++ b/lib/npg_qc/autoqc/checks/spatial_filter.pm
@@ -10,10 +10,9 @@ our $VERSION = '0';
 
 override 'execute' => sub {
   my ($self) = @_;
-  my $filter_stats_file_name_glob = $self->qc_in . q{/} . $self->id_run . '_' . $self->position . q{*.spatial_filter.stats};
-  my @filter_stats_files = glob $filter_stats_file_name_glob or
-    croak "Cannot find any filter stats files using $filter_stats_file_name_glob";
-  $self->result->parse_output(\@filter_stats_files); #read stderr from spatial_filter -a for each sample
+
+  $self->result->parse_output($self->input_files); #read stderr from spatial_filter -a for each sample
+
   return 1;
 };
 

--- a/t/data/autoqc/25830_1#1.filter.stats
+++ b/t/data/autoqc/25830_1#1.filter.stats
@@ -1,2 +1,2 @@
-Total	Processed 382658 	Failed 32768 traces
+25830_1#1	Processed 382658 	Failed 32768 traces
 

--- a/t/data/autoqc/25830_1#2.filter.stats
+++ b/t/data/autoqc/25830_1#2.filter.stats
@@ -1,2 +1,2 @@
-Total	Processed 306160 	Failed 0 traces
+25830_1#2	Processed 306160 	Failed 0 traces
 

--- a/t/data/autoqc/25830_1#3.filter.stats
+++ b/t/data/autoqc/25830_1#3.filter.stats
@@ -1,2 +1,2 @@
-Total	Processed 54332 	Failed 42 traces
+25830_1#3	Processed 54332 	Failed 42 traces
 


### PR DESCRIPTION
change spatial_filter check to use input_files attribute; parse files looking for entries for the specified id_run and position (derived from composition), summing the "Processed" and "Failed" values over the lane