### PR TITLE
limit fastqcheck files saved to lane-level files only

### DIFF
--- a/bin/npg_qc_save_files.pl
+++ b/bin/npg_qc_save_files.pl
@@ -1,15 +1,9 @@
 #!/usr/bin/env perl
 
-#########
-# Author:        Marina Gourtovaia
-# Created:       9 August 2010
-#
-
 use strict;
 use warnings;
 use FindBin qw($Bin);
 use lib ( -d "$Bin/../lib/perl5" ? "$Bin/../lib/perl5" : "$Bin/../lib" );
-use Getopt::Long;
 
 use npg_qc::file_store;
 

--- a/lib/npg_qc/file_store.pm
+++ b/lib/npg_qc/file_store.pm
@@ -1,16 +1,9 @@
-#########
-# Author:        Marina Gourtovaia
-# Created:       9 August 2010
-#
-
 package npg_qc::file_store;
 
-use strict;
-use warnings;
 use Moose;
 use namespace::autoclean;
 use Carp;
-use English qw{-no_match_vars};
+use Try::Tiny;
 use File::Spec;
 use Perl6::Slurp;
 use File::Basename;
@@ -24,31 +17,29 @@ with 'MooseX::Getopt';
 
 our $VERSION = '0';
 
-Readonly::Scalar my $DEFAULT_EXTENSION   => q[.fastqcheck];
-Readonly::Scalar our $TABLE_NAME         => q[Fastqcheck];
-Readonly::Hash our %THRESHOLDS_DB => ( 20 => 'twenty', 25 => 'twentyfive', 30 => 'thirty', 35 => 'thirtyfive', 40 => 'forty',);
-##no critic (Variables::ProhibitPunctuationVars RequireExtendedFormatting ProhibitEnumeratedClasses)
-my $FILE_NAME_REG_EXP = qr/^(\d+)_(\d)(_\d|_t)?(_[a-z]+)?(#\d+)?\.fastqcheck$/sm;
-##use critic
+Readonly::Scalar my $DEFAULT_EXTENSION => q[.fastqcheck];
+Readonly::Scalar my $TABLE_NAME        => q[Fastqcheck];
+Readonly::Hash   my %THRESHOLDS_DB     => ( 20 => 'twenty',
+                                            25 => 'twentyfive',
+                                            30 => 'thirty',
+                                            35 => 'thirtyfive',
+                                            40 => 'forty', );
 
-has 'path'            => (  isa         => 'ArrayRef',
-                            is          => 'rw',
-                            required    => 1,
+my $FILE_NAME_REG_EXP = qr/\A(\d+)_(\d)(_\d|_t)?[.]fastqcheck\Z/smx;
+
+has 'path'            => (  isa           => 'ArrayRef',
+                            is            => 'ro',
+                            required      => 1,
                             documentation =>
   'a path to a directory with the files to be saved; multiple paths (an array) are accepted',
                          );
 
 has 'schema' =>    ( isa        => 'npg_qc::Schema',
+                     metaclass  => 'NoGetopt',
                      is         => 'ro',
                      required   => 0,
                      lazy_build => 1,
                    );
-
-has 'table_name' => ( isa        => 'Str',
-                      is         => 'ro',
-                      required   => 0,
-                      default    => $TABLE_NAME,
-                    );
 
 sub _build_schema {
   my $self = shift;
@@ -56,14 +47,10 @@ sub _build_schema {
 }
 
 sub _get_files {
-  my ($self) = @_;
-
+  my $self = shift;
   my @all_files = ();
   foreach my $path (@{$self->path}) {
-    my @files = glob File::Spec->catfile($path, q[*] . $DEFAULT_EXTENSION);
-    if (@files) {
-      push @all_files, @files;
-    }
+    push @all_files, (glob File::Spec->catfile($path, q[*] . $DEFAULT_EXTENSION));
   }
   return \@all_files;
 }
@@ -80,64 +67,50 @@ sub _qvalues {
   return;
 }
 
-sub fname2ids {
+sub _fname2ids {
   my $fname = shift;
 
-  my ($id_run, $position, $read, $split, $tag_index) = $fname =~ $FILE_NAME_REG_EXP;
-  if (!$id_run) {
-    croak "Cannot infer id_run from filename $fname";
-  }
-  if (!$position) {
-    croak "Cannot infer position from filename $fname";
-  }
-
-  if (!$read || $read eq '_1') {
-    $read = 'forward';
-  } elsif ($read eq '_2') {
-    $read = 'reverse';
-  } elsif ($read eq '_t') {
-    $read = 'index';
-  } else {
-    croak "Unknown read type $read in $fname";
+  my ($id_run, $position, $read) = $fname =~ $FILE_NAME_REG_EXP;
+  if ($id_run && $position) {
+    if (!$read || $read eq '_1') {
+      $read = 'forward';
+    } elsif ($read eq '_2') {
+      $read = 'reverse';
+    } elsif ($read eq '_t') {
+      $read = 'index';
+    } else {
+      croak "Unknown read type $read in $fname";
+    }
+    return {'id_run' => $id_run, 'position' => $position, 'section' => $read};
   }
 
-  my $ids = {id_run => $id_run, position => $position, section => $read,};
-  if (defined $tag_index) {
-    $tag_index =~ s/^\#//smx;
-    $ids->{tag_index} = $tag_index;
-  }
-  if ($split) {
-    $split =~ s/^_//smx;
-    $ids->{split} = $split;
-  }
-
-  return $ids;
+  return;
 }
 
 sub save_files {
   my $self = shift;
 
   my $count = 0;
-  my $rs = $self->schema->resultset($self->table_name);
+  my $rs = $self->schema->resultset($TABLE_NAME);
   foreach my $file (@{$self->_get_files}) {
-    my $transaction = sub {
-      my ($fname, $dir, $ext) = fileparse($file);
-      my $values = fname2ids($fname);
-
-      my $content = slurp $file;
-      $values->{file_content} = $content;
-      $values->{file_name} = $fname;
-      $values->{file_content_compressed} = compress($content);
-      _qvalues($values, $content);
-      $rs->find_or_new($values)->set_inflated_columns($values)->update_or_insert();
-		          };
-    eval {
-      $self->schema->txn_do($transaction);
-      $count++;
-      1;
-    } or do {
-      croak "Failed to load $file to the database: $EVAL_ERROR";
-    };
+    my ($fname, $dir, $ext) = fileparse($file);
+    my $values = _fname2ids($fname);
+    if ($values) {
+      my $transaction = sub {
+        my $content = slurp $file;
+        $values->{'file_content'} = $content;
+        $values->{'file_name'} = $fname;
+        $values->{'file_content_compressed'} = compress($content);
+        _qvalues($values, $content);
+        $rs->find_or_new($values)->set_inflated_columns($values)->update_or_insert();
+		  };
+      try {
+        $self->schema->txn_do($transaction);
+        $count++;
+      } catch {
+        croak "Failed to load $file to the database: $_";
+      };
+    }
   }
   return $count;
 }
@@ -145,6 +118,7 @@ sub save_files {
 __PACKAGE__->meta->make_immutable;
 
 1;
+
 __END__
 
 =head1 NAME
@@ -157,19 +131,16 @@ npg_qc::file_store
 
 =head1 DESCRIPTION
 
-Saves into a database fastqcheck files found in the given paths. Also saves a numver of qX values.
+Saves into a database fastqcheck files found in the given paths. Also saves a number of qX values.
+Only lane-level files are saved.
 
 =head1 SUBROUTINES/METHODS
 
 =head2 path - an attribute; a reference to an array of paths where the files to be saved are located
 
-=head2 save_files 
-
 =head2 schema - an attribute; DBIx schema object for the NPG QC database
 
 =head2 save_files - finds fastqcheck files in the given paths, reads the content and loads in to NPG QC database
-
-=head2 fname2ids
 
 =head1 DIAGNOSTICS
 
@@ -187,13 +158,17 @@ Saves into a database fastqcheck files found in the given paths. Also saves a nu
 
 =item Carp
 
-=item English qw{-no_match_vars}
+=item Try::Tiny
 
 =item File::Spec
 
 =item Perl6::Slurp
 
 =item File::Basename
+
+=item MooseX::Getopt
+
+=item Compress::Zlib
 
 =item npg_qc::Schema
 
@@ -209,7 +184,7 @@ Marina Gourtovaia, E<lt>mg8@sanger.ac.ukE<gt>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2010 GRL, by Marina Gourtovaia
+Copyright (C) 2018 GRL Genome Research Ltd
 
 This library is free software; you can redistribute it and/or modify
 it under the same terms as Perl itself, either Perl version 5.8.8 or,

--- a/lib/npg_qc/file_store.pm
+++ b/lib/npg_qc/file_store.pm
@@ -25,7 +25,12 @@ Readonly::Hash   my %THRESHOLDS_DB     => ( 20 => 'twenty',
                                             35 => 'thirtyfive',
                                             40 => 'forty', );
 
-my $FILE_NAME_REG_EXP = qr/\A(\d+)_(\d)(_\d|_t)?[.]fastqcheck\Z/smx;
+my $FILE_NAME_REG_EXP = qr{\A
+                             (\d+)             # run id
+                            _(\d)              # position
+                            (_\d|_t)?          # optional read
+                           $DEFAULT_EXTENSION  # file extension
+                           \Z}smx;
 
 has 'path'            => (  isa           => 'ArrayRef',
                             is            => 'ro',
@@ -103,7 +108,7 @@ sub save_files {
         $values->{'file_content_compressed'} = compress($content);
         _qvalues($values, $content);
         $rs->find_or_new($values)->set_inflated_columns($values)->update_or_insert();
-		  };
+      };
       try {
         $self->schema->txn_do($transaction);
         $count++;

--- a/t/10-file_store.t
+++ b/t/10-file_store.t
@@ -1,13 +1,7 @@
-#########
-# Author:        mg8
-# Created:       9 August 2010
-#
-
 use strict;
 use warnings;
-use Test::More tests => 36;
+use Test::More tests => 25;
 use Test::Exception;
-use Test::Deep;
 use Perl6::Slurp;
 use File::Spec;
 use Moose::Meta::Class;
@@ -17,34 +11,30 @@ use npg_testing::db;
 
 use_ok('npg_qc::file_store');
 
-isa_ok(npg_qc::file_store->new(path => ['t']), 'npg_qc::file_store');
-
-throws_ok {npg_qc::file_store->new()} qr/Attribute \(path\) is required /, 'error if path is not set';
-
-{
-  my $s = npg_qc::file_store->new(path => ['t/data/fastqcheck/4308']);
-  is ($s->table_name, 'Fastqcheck', 'table name to save to correct');
-  is (scalar @{$s->_get_files}, 3, '3 fastqcheck files found');
-}
-
-{
-  cmp_deeply(npg_qc::file_store::fname2ids('111_3_1#4.fastqcheck'),
-    {id_run =>111,position=>3,tag_index=>4,section=>'forward',}, 'forward plex filename parsed');
-  cmp_deeply(npg_qc::file_store::fname2ids('111_3_2#4.fastqcheck'),
-    {id_run =>111,position=>3,tag_index=>4,section=>'reverse',}, 'reverse plex filename parsed');
-  cmp_deeply(npg_qc::file_store::fname2ids('111_3.fastqcheck'),
-    {id_run =>111,position=>3,section=>'forward',}, 'single lane filename parsed');
-  cmp_deeply(npg_qc::file_store::fname2ids('111_3#0.fastqcheck'),
-    {id_run =>111,position=>3,tag_index=>0,section=>'forward',}, 'unknown read can be interpreted as a split');
-  cmp_deeply(npg_qc::file_store::fname2ids('111_3_m#4.fastqcheck'),
-    {id_run =>111,position=>3,tag_index=>4,split=>'m',section=>'forward',}, 'single tag 0 filename parsed');
-  throws_ok { npg_qc::file_store::fname2ids('111_3_m_phix#4.fastqcheck') }
-     qr/Cannot infer id_run/, 'error if read value unexpected'; 
-}
-
 my $schema = Moose::Meta::Class->create_anon_class(
           roles => [qw/npg_testing::db/])
           ->new_object({})->create_test_db(q[npg_qc::Schema]);
+{
+  isa_ok(npg_qc::file_store->new(path => ['t']), 'npg_qc::file_store');
+  throws_ok {npg_qc::file_store->new()} qr/Attribute \(path\) is required /, 'error if path is not set';
+}
+
+{
+  my $s = npg_qc::file_store->new(path => ['t/data/fastqcheck/4308']);
+  is (scalar @{$s->_get_files}, 3, 'three fastqcheck files found');
+}
+
+{
+  ok(!npg_qc::file_store::_fname2ids('111_3_1#4.fastqcheck'), 'plex level file excluded');
+  ok(!npg_qc::file_store::_fname2ids('111_3_1_phix.fastqcheck'), 'file for a subset excluded');
+ 
+  is_deeply(npg_qc::file_store::_fname2ids('111_3.fastqcheck'),
+    {id_run =>111,position=>3,section=>'forward'}, 'implicit forward read filename parsed');
+  is_deeply(npg_qc::file_store::_fname2ids('111_3_1.fastqcheck'),
+    {id_run =>111,position=>3,section=>'forward'}, 'forward read filename parsed');
+  is_deeply(npg_qc::file_store::_fname2ids('111_3_2.fastqcheck'),
+    {id_run =>111,position=>3,section=>'reverse'}, 'reverse read filename parsed');
+}
 
 {
   my $s = npg_qc::file_store->new(path => ['t/data/autoqc/npg'], schema => $schema);
@@ -52,24 +42,29 @@ my $schema = Moose::Meta::Class->create_anon_class(
   my $num_saved;
   lives_ok {$num_saved = $s->save_files} 'saving files when there are no files lives';
   is ($num_saved, 0, 'no files are saved');
+
+  $s = npg_qc::file_store->new(path => ['t/data/autoqc/npg', 't/some'],
+                               schema => $schema);
+  is (scalar @{$s->_get_files}, 0,
+    'no fqcheck files found, one of the given directories does not exist');
 }
 
 {
-  my $table = 'Fastqcheck';
+  my $rs = $schema->resultset('Fastqcheck');
 
   my $path = 't/data/fastqcheck/4308';
-  my $s = npg_qc::file_store->new(path => [$path], schema => $schema, table_name => $table);
+  my $s = npg_qc::file_store->new(path => [$path], schema => $schema);
   my $num_saved;
   lives_ok {$num_saved = $s->save_files} 'saving files lives';
-  my $expected = 3;
-  is ($num_saved, $expected, qq[$expected files saved]);
 
-  is ($schema->resultset($table)->search({})->count, $expected, qq[$expected rows created in the table]);
+  is ($num_saved, 1, qq[one file saved]);
+
+  is ($rs->search({})->count, 1, qq[one row created in the table]);
 
   my $fname=  q[4308_1_2.fastqcheck];
   my $content = slurp(File::Spec->catfile($path, $fname));
 
-  my $row = $schema->resultset($table)->find({file_name => $fname,});
+  my $row = $rs->find({file_name => $fname,});
   ok ($row, qq[row for $fname exists]);
   is ($row->file_content, $content, 'file content saved correctly');
   is (uncompress($row->file_content_compressed), $content, 'compressed file content saved correctly');
@@ -79,20 +74,6 @@ my $schema = Moose::Meta::Class->create_anon_class(
   is ($row->thirtyfive, 393329004, 'q35 saved');
   is ($row->forty, 0, 'q40 saved');
   is ($row->tag_index, undef, 'tag index returned as undef');
-
-  $row = $schema->resultset($table)->find({file_name => '4308_4_2#5.fastqcheck',});
-  is ($row->tag_index, 5, 'tag index 5');
-  is ($row->position, 4, 'position 4');
-  is ($row->id_run, 4308, 'id run 4308');
-  is ($row->section, 'reverse', 'reverse read saved');
-  is ($row->split, undef, 'no split');
-
-  $row = $schema->resultset($table)->find({file_name => '4308_4#5.fastqcheck',});
-  is ($row->tag_index, 5, 'tag index 5');
-  is ($row->position, 4, 'position 4');
-  is ($row->id_run, 4308, 'id run 4308');
-  is ($row->section, 'forward', 'forward read saved');
-  is ($row->split, undef, 'no split');
 }
 
 1;


### PR DESCRIPTION
The naming convention for fastqcheck plex-level files has changed, the location of these files in the run folder has changed and we will soon not need these files anyway, so went for a simple option.

However, we will lose q30 and q40 yeilds on plex level in the warehouse. We are going to extend qx yield autoqc check to capture those and then load to the wh. Meanwhile, this pr should wait.