### PR TITLE
spatial_filter check input spec change

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -23,6 +23,7 @@ my $requires = {
                 'Fatal'                           => 0,
                 'Fcntl'                           => 0,
                 'File::Basename'                  => 0,
+                'File::Find'                      => 0,
                 'File::Glob'                      => 0,
                 'File::Path'                      => 0,
                 'File::Spec'                      => 0,

--- a/Changes
+++ b/Changes
@@ -25,6 +25,9 @@ LIST OF CHANGES FOR NPG-QC PACKAGE
    component compositions
  - Illumina QC data loader restricted to loading cluster density data, its
     data pre-loading functionality dropped
+ - amend spatial_filter check to take a directory name to search instead
+    of an explicit list of input files (that approach became unworkable
+    with highly plexed lanes)
 
 release 65.4
  - qX_yield autoqc check extension: capture and save yields for q30 and q40

--- a/MANIFEST
+++ b/MANIFEST
@@ -209,6 +209,7 @@ t/60-autoqc-checks-qX_yield.t
 t/60-autoqc-checks-ref_match.t
 t/60-autoqc-checks-rna_seqc.t
 t/60-autoqc-checks-sequence_error.t
+t/60-autoqc-checks-spatial_filter.t
 t/60-autoqc-checks-tag_metrics.t
 t/60-autoqc-checks-tags_reporters.t
 t/60-autoqc-checks-upstream_tags.t

--- a/lib/npg_qc/autoqc/checks/check.pm
+++ b/lib/npg_qc/autoqc/checks/check.pm
@@ -269,7 +269,8 @@ sub _build_result {
   }
   $nref->{'composition'} = $self->composition;
   if ($self->has_qc_in) {
-    $nref->{'path'} = $self->qc_in;
+    # We'll capture one path only. Can be changed in the future.
+    $nref->{'path'} = ref $self->qc_in ? $self->qc_in->[0] : $self->qc_in;
   }
   if ($self->can('subset') && $self->subset) {
     $nref->{'subset'} = $self->subset;

--- a/lib/npg_qc/autoqc/checks/check.pm
+++ b/lib/npg_qc/autoqc/checks/check.pm
@@ -141,8 +141,11 @@ has 'qc_in'        => (isa        => 'Str',
                       );
 sub _test_qc_in {
   my ($self, $qc_in) = @_;
-  if (!-R $qc_in) {
-    croak qq[Input qc directory $qc_in does not exist or is not readable];
+
+  foreach my $d ( ref $qc_in ? @{$qc_in} : ($qc_in) ) {
+    if (!-R $d) {
+      croak qq[Input qc directory $d does not exist or is not readable];
+    }
   }
   return;
 }

--- a/lib/npg_qc/autoqc/checks/spatial_filter.pm
+++ b/lib/npg_qc/autoqc/checks/spatial_filter.pm
@@ -45,7 +45,7 @@ override 'execute' => sub {
 
   my @infiles=();
 
-  find(sub { if( /spatial_filter.stats$/ ) { push @infiles, $File::Find::name }}, @{$self->qc_in_roots});
+  find(sub { if( /spatial_filter.stats$/smx ) { push @infiles, $File::Find::name }}, @{$self->qc_in_roots});
 
   $self->result->parse_output(\@infiles); #read stderr from spatial_filter -a for each sample
 

--- a/t/60-autoqc-checks-spatial_filter.t
+++ b/t/60-autoqc-checks-spatial_filter.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 4;
+use Test::More tests => 6;
 use Test::Exception;
 use File::Temp qw/tempdir/;
 
@@ -25,9 +25,11 @@ use_ok('npg_qc::autoqc::checks::spatial_filter');
     close $fh;
   }
 
-  $check = npg_qc::autoqc::checks::spatial_filter->new(
-    position => 2, id_run => 2549, qc_in => \@dirs);
+  $check = npg_qc::autoqc::checks::spatial_filter->new(rpt_list=>'2549:2', qc_in => \@dirs);
   is_deeply ($check->input_files, \@files, 'input files found');
+
+  lives_ok {$check->result} 'can create result object';
+  is ($check->result->path, $dirs[0], 'first path captured');
 }
 
 1;

--- a/t/60-autoqc-checks-spatial_filter.t
+++ b/t/60-autoqc-checks-spatial_filter.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use Test::More tests => 4;
+use Test::Exception;
+use File::Temp qw/tempdir/;
+
+use_ok('npg_qc::autoqc::checks::spatial_filter');
+
+{
+  my $check = npg_qc::autoqc::checks::spatial_filter->new(
+    position => 2, id_run => 2549, qc_in => ['t']);
+  isa_ok ($check, 'npg_qc::autoqc::checks::spatial_filter');
+  throws_ok { $check->execute() } qr/input_files array cannot be empty/,
+    'error when no input files are found';
+
+  my $dir = tempdir( CLEANUP => 1 );
+  my @dirs = map { join q[/], $dir, $_} qw/a b c d f/;
+  map { mkdir $_ } @dirs;
+  my @data_dirs = @dirs;
+  pop @data_dirs;
+  my @files = sort map { join q[/], $_, 'some.spatial_filter.stats'} @data_dirs;
+  for my $f (@files) {
+    open my $fh, '>', $f or die 'Cannnot open file';
+    print $fh 'some';
+    close $fh;
+  }
+
+  $check = npg_qc::autoqc::checks::spatial_filter->new(
+    position => 2, id_run => 2549, qc_in => \@dirs);
+  is_deeply ($check->input_files, \@files, 'input files found');
+}
+
+1;


### PR DESCRIPTION
use search directory to locate spatial_filter.stats files instead of an explicit list of input files (unworkable with highly plexed lanes)