### PR TITLE
composite genotype check should only use iRODS data for recalling (no…

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ release 66.1
  - autoqc results loader to check for potential composition digest clashes
  - amend upstream_tags check to find previous runs which have reached
      status "analysis complete" (instead of "run complete")
+ - composite genotype check script (call_gtck_composite_rpt.pl) search
+     for run folders disabled - only use iRODS cram files
 
 release 66.0
  - GUI for utility QC (inactive)

--- a/bin/call_gtck_composite_rpt.pl
+++ b/bin/call_gtck_composite_rpt.pl
@@ -130,6 +130,9 @@ print $of $result_string;
 sub find_runlanefolder {
 	my ($id_run, $lane, $tag_index, $ext) = @_;
 
+	# temporarily disable search for run folder (assumptions about its structure are out of date)
+	return;
+
 	# the methods hash ref passed to create_anon_class looks peculiar, but seems to be necessary to create a new object
 	#  from an anonymous class in this way
         my $runfolder = Moose::Meta::Class->create_anon_class(


### PR DESCRIPTION
…t runfolder)