### PR TITLE
Deterministic ref match organism sort

### DIFF
--- a/lib/npg_qc/autoqc/role/ref_match.pm
+++ b/lib/npg_qc/autoqc/role/ref_match.pm
@@ -52,10 +52,12 @@ sub top_two {
   my @top_two = ();
   for (qw/1 2/) {
     my $organism = shift @ranked;
-    $organism or next;
+    $organism or last;
     my $strain = $self->reference_version->{$organism};
+    my $percent = $ratings->{$organism};
     $organism =~ s/_/ /xms;
-    push @top_two, join q[ ], $organism, $strain;
+    $organism = join q[ ], $organism, $strain;
+    push @top_two, {name => $organism, percent => $percent};
   }
   return @top_two;
 }
@@ -92,7 +94,9 @@ sorted alphabetically. The sort order is better alignment first.
 
 =head2 top_two
 
-Return a list of top two opgamisms (together with strain/reference version).
+Return a list of up to two hash references, each containing the
+organist name and version/strain and corresponding to it percent
+mapped.
 
 =head1 DIAGNOSTICS
 

--- a/npg_qc_viewer/root/src/ui_checks/ref_match.tt2
+++ b/npg_qc_viewer/root/src/ui_checks/ref_match.tt2
@@ -29,9 +29,10 @@
     <th>percent</th>
   </tr>
 
-  [% FOREACH organism IN check.ranked_organisms -%]
-    [%- pcount = check.percent_count.item(organism);
-       IF pcount != '0.0' && pcount != '0.1';
+  [% percent_count = check.percent_count;
+    FOREACH organism IN check.ranked_organisms(percent_count) -%]
+    [%- pcount = percent_count.item(organism);
+        IF pcount != '0.0' && pcount != '0.1';
     - %]
     <tr>
       <td><span class="dark_blue">[% organism | replace('_', ' ') %]</span> [% check.reference_version.item(organism) %]</td>

--- a/npg_qc_viewer/root/src/ui_lanes/lane.tt2
+++ b/npg_qc_viewer/root/src/ui_lanes/lane.tt2
@@ -151,11 +151,12 @@
 [%- END -%]
 
 [% BLOCK ref_match -%]
-[%- IF result.aligned_read_count.defined; ranked_orgs = result.ranked_organisms -%]
+[%- IF result.aligned_read_count.defined;
+      percent_count = result.percent_count;
+      ranked_orgs = result.ranked_organisms(percent_count);
 
-
-[%-   IF ranked_orgs.0.defined;
-        match = result.percent_count.item(ranked_orgs.0);
+      IF ranked_orgs.0.defined;
+        match = percent_count.item(ranked_orgs.0);
         padding = ' ';
         IF match < 10; padding = '  '; END;
 -%]
@@ -163,7 +164,7 @@
 [%-   END -%]
 
 [%-   IF ranked_orgs.1.defined;
-        match = result.percent_count.item(ranked_orgs.1);
+        match = percent_count.item(ranked_orgs.1);
         padding = ' ';
         IF match < 10; padding = '  '; END;
 -%]

--- a/t/60-autoqc-results-ref_match.t
+++ b/t/60-autoqc-results-ref_match.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 16;
+use Test::More tests => 17;
 use Test::Exception;
 
 use_ok('npg_qc::autoqc::results::ref_match');
@@ -14,6 +14,7 @@ my $r = npg_qc::autoqc::results::ref_match->new(
 isa_ok( $r, 'npg_qc::autoqc::results::ref_match' );
 is( $r->check_name(), 'ref match', 'Check name' );
 is( $r->class_name(), 'ref_match', 'Class name' );
+is_deeply(scalar $r->top_two, 0, 'no data - empty list for top two');
 
 $r->aligned_read_count(
     {
@@ -83,8 +84,8 @@ is_deeply(
 is_deeply(
     [$r->top_two()],
     [
-        'Homo sapiens NCBI37',
-        'Clostridium difficile Strain_630',
+        {name => 'Homo sapiens NCBI37',              percent => '50.0'},
+        {name => 'Clostridium difficile Strain_630', percent => '3.0'}
     ],
     'Top two'
 );


### PR DESCRIPTION
To optimise loading of the ml warehouse, we need deterministic top two matches