### PR TITLE
call_gtck_composite_rpt.pl now defaults to cram inputs from iRODS : -…

### DIFF
--- a/bin/call_gtck_composite_rpt.pl
+++ b/bin/call_gtck_composite_rpt.pl
@@ -39,7 +39,7 @@ use npg_qc::autoqc::checks::genotype;
 our $VERSION = '0';
 
 my %opts;
-getopts('hr:s:p:jo:g:m:a:x:c', \%opts);
+getopts('hr:s:p:jo:g:m:a:x:b', \%opts);
 
 ##########
 # rpt key list should be in the format <id_run>:<lane>[:tag];... These values are then used to construct the bam file names:
@@ -48,7 +48,7 @@ getopts('hr:s:p:jo:g:m:a:x:c', \%opts);
 #  otherwise, look in iRODS archive: 9213:6:40;8213:1:4 yields ("irods:/seq/9213/9213_6#40.bam", "irods:/seq/8213/8213_1#4.bam")
 ##########
 my @bam_file_list;
-my $ext = $opts{c}? q[cram]: q[bam];
+my $ext = $opts{b}? q[bam]: q[cram];
 my $rpt_list = $opts{r};
 if($rpt_list) {
 	@bam_file_list = map { my ($r, $p, $t) = (split ":", $_); find_runlanefolder($r, $p, $t, $ext) or sprintf "irods:/seq/%d/%d_%d%s.%s", $r, $r, $p, $t? "#$t": "", $ext; } (split ";", $rpt_list);


### PR DESCRIPTION
…c flag replaced by -b flag (to override default behaviour)