### PR TITLE
sequence_summary "header" column type changed from text to mediumtext

### DIFF
--- a/lib/npg_qc/Schema/Result/SequenceSummary.pm
+++ b/lib/npg_qc/Schema/Result/SequenceSummary.pm
@@ -80,7 +80,7 @@ Sequencing file format, e.g. SAM, BAM
 
 =head2 header
 
-  data_type: 'text'
+  data_type: 'mediumtext'
   is_nullable: 0
 
 File header, excluding SQ lines, the field is searchable
@@ -145,7 +145,7 @@ __PACKAGE__->add_columns(
   'sequence_format',
   { data_type => 'varchar', is_nullable => 0, size => 6 },
   'header',
-  { data_type => 'text', is_nullable => 0 },
+  { data_type => 'mediumtext', is_nullable => 0 },
   'seqchksum',
   { data_type => 'text', is_nullable => 0 },
   'seqchksum_sha512',
@@ -198,8 +198,8 @@ __PACKAGE__->belongs_to(
 );
 
 
-# Created by DBIx::Class::Schema::Loader v0.07043 @ 2015-09-09 17:35:44
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:glQpr8F7Nst/qIueaRFUEA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2019-02-20 14:17:45
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:1Hz8njwstffBZXOLjCvIyQ
 
 
 # You can replace this text with custom code or comments, and it will be preserved on regeneration

--- a/scripts/upgrade_schema/upgrade_schema-66.3
+++ b/scripts/upgrade_schema/upgrade_schema-66.3
@@ -1,0 +1,3 @@
+ALTER TABLE `sequence_summary` \
+MODIFY COLUMN `header` MEDIUMTEXT NOT NULL \
+COMMENT 'File header, excluding SQ lines, the field is searchable';


### PR DESCRIPTION
Header for tag zero for a deeply plexed pool is too large for the existing type 'text'