### PR TITLE
fix regular expression in collapse.js

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
+ - fix regular expression used in collapse after change in template
  - adapter check switched to use cram files
  - record absolute path of the verifyBamID executable
 

--- a/npg_qc_viewer/root/src/ui_checks/checks_in_full.tt2
+++ b/npg_qc_viewer/root/src/ui_checks/checks_in_full.tt2
@@ -85,10 +85,10 @@
         <h2 class="collapser [% check.check_name %]">[% util.expand_rpt_key(lane_key) %], [% check.check_name -%]
 
 	[%- IF check.pass.defined -%]:
-		[% check.pass ? ' passed' : '<span class="result_fail"> failed</span>' -%]
+		[% check.pass ? ' passed' : '<span class="result_fail"> failed</span>' -%] [%# Text produced in this section affects behaviour of js code for collapse library %]
 	[%- END -%]
 	</h2>
-  
+
 	<div class="result_full_content">
 	[% TRY -%]
 		[% PROCESS "ui_checks/${check.class_name}.tt2" -%]

--- a/npg_qc_viewer/root/static/scripts/collapse.js
+++ b/npg_qc_viewer/root/static/scripts/collapse.js
@@ -117,7 +117,7 @@ define(['jquery'], function() {
         var mySections = [];
 
         // Regular expression to filter sections, considers pass/fail
-        var pattern = new RegExp(self.data('section') + '(:\\w+)?$');
+        var pattern = new RegExp(self.data('section') + '(:\\s*\\w+)?$');
         $.each(allHeaders, function(index, obj) {
           if ( pattern.test($(obj).text().trim()) ) {
             var nextDiv = $($(obj).next('div'));


### PR DESCRIPTION
  Breaking change in template caused collapse to ignore divs
  where check was marked as passed or failed.