### PR TITLE
filter out artic header

### DIFF
--- a/bin/npg_simple_robo4artic
+++ b/bin/npg_simple_robo4artic
@@ -37,6 +37,10 @@ my $line_number = 0;
 while (my $line = <STDIN>) {
 ##use critic
   $line_number++;
+
+  if ($line =~ /\Asample_name,/smx) { # header, skip
+    next;
+  }
   my $l = "Line $line_number:";
   my $outcome;
   my $file_name_root;


### PR DESCRIPTION
Previously I filtered out the header with grep before piping into the script. Does not work in the pipeline if artic's QC summary file is empty.