### PR TITLE
bug fix for the order of assignment of keys

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
+release 68.7.1
+ - bug fix for the order of assignment of keys for the doc->{'meta'}
+   part of the generic result object for the ncov2019_artic_nf pp
+
 release 68.7.0
  - ability to invoke, via the qc script, specialised versions of
    autoqc checks

--- a/bin/npg_autoqc_generic4artic
+++ b/bin/npg_autoqc_generic4artic
@@ -176,12 +176,13 @@ sub _set_result_attributes {
     $g->result->doc->{$ARTIC_METRICS_NAME} = $summary;
   }
 
+  $g->result->doc->{'meta'} = $g->get_sample_info();
+
   # Supplimentary information to help evaluate the QC output or its
   # absence.
   if (defined $num_ireads) {
     $g->result->doc->{'meta'}->{'num_input_reads'} = $num_ireads;
   }
-  $g->result->doc->{'meta'} = $g->get_sample_info();
 
   # Info about this script and pp.
   $g->result->set_info('Script_name', $Script);


### PR DESCRIPTION
`$g->result->doc->{meta}->{num_input_reads} `was missing in the result object because the hash ref assigned to `$g->result->doc->{meta}` was overwritted by `$g->result->doc->{'meta'} = $g->get_sample_info();`

Now the order of the assignments is reversed.