### PR TITLE
add gbs_plex option to genotype_call_results_reporter

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
+ - add option to restrict to a single gbs_plex to genotype_call_results_reporter
+
 release 69.2.0
  - the mqc skipper script is changed to always take into account the outcome
    of RoboQC assessment

--- a/bin/genotype_call_results_reporter
+++ b/bin/genotype_call_results_reporter
@@ -23,6 +23,7 @@ genotype_call_results_reporter
   genotype_call_results_reporter
   genotype_call_results_reporter --verbose 
   genotype_call_results_reporter --verbose --dry_run
+  genotype_call_results_reporter --verbose --gbs_plex Minor_v1.0 --dry_run
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
It's likely PSD will only utilise results from human QC plexes within SM and therefore adding an option so only those results can be posted back to their API.