### PR TITLE
Add Node.js version build matrix

### DIFF
--- a/.github/workflows/testing_and_building_repos.yml
+++ b/.github/workflows/testing_and_building_repos.yml
@@ -1,7 +1,7 @@
 name: testing_and_building_repo
 on: [push, pull_request]
 jobs:
-  build: 
+  build:
     strategy:
       fail-fast: false
       matrix:
@@ -9,7 +9,7 @@ jobs:
         perl: ['5.26']
         node: ['14.8.0']
 
-    runs-on: ${{matrix.os}} 
+    runs-on: ${{ matrix.os }}
 
     defaults:
       run:
@@ -19,17 +19,17 @@ jobs:
       WSI_CONDA_CHANNEL: "https://dnap.cog.sanger.ac.uk/npg/conda/devel/generic"
       NPM_CONFIG_PREFIX: "$HOME/.npm-global"
 
-    name: Perl ${{ matrix.perl }} and Node ${{ matrix.node }} on ${{ matrix.os }}  
+    name: Perl ${{ matrix.perl }} and Node ${{ matrix.node }} on ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2 
-    
+    - uses: actions/checkout@v2
+
     # Caching cpanm external modules
     - name: Cache cpanm external modules
       id: cpanmCache
       uses: actions/cache@v2
       with:
         path: ~/perl5ext
-        key: ${{ matrix.os}}-build-cpanm-external
+        key: ${{ matrix.os }}-build-cpanm-external
 
     - name: Initialize Miniconda
       run: |
@@ -43,17 +43,17 @@ jobs:
         path: |
           ~/conda/pkgs
           ~/conda/envs
-        key: ${{ matrix.os}}-build-miniconda
+        key: ${{ matrix.os }}-build-miniconda
 
-    - name: install libgd-dev and uuid-dev 
+    - name: install libgd-dev and uuid-dev
       run:
-          sudo apt-get install -y libgd-dev uuid-dev 
-    
+          sudo apt-get install -y libgd-dev uuid-dev
+
     - name: install conda client, baton,samtools, set up conda environment
       run: |
           conda config --prepend pkgs_dirs ~/conda/pkgs
           conda config --prepend envs_dirs ~/conda/envs
-          
+
           conda config --set auto_update_conda False
           conda config --prepend channels "$WSI_CONDA_CHANNEL"
           conda config --append channels conda-forge
@@ -63,11 +63,9 @@ jobs:
           conda install -y -n "$CONDA_TEST_ENV" nodejs=="${{ matrix.node }}"
           conda install -y -n "$CONDA_TEST_ENV" npg_qc_utils
           conda install -y -n "$CONDA_TEST_ENV" baton
-          conda activate "$CONDA_TEST_ENV"
       env:
-        CONDA_CHANNEL: https://dnap.cog.sanger.ac.uk/npg/conda/devel/generic
         CONDA_TEST_ENV: test-environment
- 
+
     - name: install cpanm
       run: |
           wget -qO - https://cpanmin.us | /usr/bin/perl - --sudo App::cpanminus
@@ -80,16 +78,16 @@ jobs:
           ${GITHUB_WORKSPACE}/scripts/before_install.sh $NPM_VERSION
 
           cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
-          ${GITHUB_WORKSPACE}/scripts/install.sh $WTSI_NPG_BUILD_BRANCH $WTSI_NPG_GITHUB_URL 
+          ${GITHUB_WORKSPACE}/scripts/install.sh $WTSI_NPG_BUILD_BRANCH $WTSI_NPG_GITHUB_URL
       env:
         NPM_VERSION: "4.5.0"
-        WTSI_NPG_BUILD_BRANCH: ${GITHUB_HEAD_REF} 
+        WTSI_NPG_BUILD_BRANCH: ${GITHUB_HEAD_REF}
         WTSI_NPG_GITHUB_URL: https://github.com/wtsi-npg
 
     - name: run script
       run: |
           export PATH="$HOME/miniconda/bin:$PATH"
-          conda activate "$CONDA_TEST_ENV" 
+          conda activate "$CONDA_TEST_ENV"
           conda info --envs
           cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
           ${GITHUB_WORKSPACE}/scripts/script.sh "${{ matrix.node }}" $WTSI_NPG_BUILD_BRANCH

--- a/.github/workflows/testing_and_building_repos.yml
+++ b/.github/workflows/testing_and_building_repos.yml
@@ -19,7 +19,7 @@ jobs:
       WSI_CONDA_CHANNEL: "https://dnap.cog.sanger.ac.uk/npg/conda/devel/generic"
       NPM_CONFIG_PREFIX: "$HOME/.npm-global"
 
-    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}  
+    name: Perl ${{ matrix.perl }} and Node ${{ matrix.node }} on ${{ matrix.os }}  
     steps:
     - uses: actions/checkout@v2 
     

--- a/.github/workflows/testing_and_building_repos.yml
+++ b/.github/workflows/testing_and_building_repos.yml
@@ -10,13 +10,14 @@ jobs:
         node: ['14.8.0']
 
     runs-on: ${{matrix.os}} 
-    
+
     defaults:
       run:
         shell: bash -l -e -o pipefail {0}
 
     env:
       WSI_CONDA_CHANNEL: "https://dnap.cog.sanger.ac.uk/npg/conda/devel/generic"
+      NPM_CONFIG_PREFIX: "$HOME/.npm-global"
 
     name: Perl ${{ matrix.perl }} on ${{ matrix.os }}  
     steps:
@@ -73,8 +74,11 @@ jobs:
 
     - name: Run install scripts
       run: |
-          echo "$HOME/miniconda/samtools/bin" >> $GITHUB_PATH 
+          echo "$HOME/miniconda/samtools/bin" >> $GITHUB_PATH
+
+          mkdir -p "$NPM_CONFIG_PREFIX"
           ${GITHUB_WORKSPACE}/scripts/before_install.sh $NPM_VERSION
+
           cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
           ${GITHUB_WORKSPACE}/scripts/install.sh $WTSI_NPG_BUILD_BRANCH $WTSI_NPG_GITHUB_URL 
       env:
@@ -84,7 +88,6 @@ jobs:
 
     - name: run script
       run: |
-          export PATH="$HOME/.npm-global/bin:$PATH"
           export PATH="$HOME/miniconda/bin:$PATH"
           conda activate "$CONDA_TEST_ENV" 
           conda info --envs

--- a/.github/workflows/testing_and_building_repos.yml
+++ b/.github/workflows/testing_and_building_repos.yml
@@ -3,10 +3,12 @@ on: [push, pull_request]
 jobs:
   build: 
     strategy:
+      fail-fast: false
       matrix:
         os: ['ubuntu-18.04']
-        perl: ['5.26'] 
-        
+        perl: ['5.26']
+        node: ['14.8.0']
+
     runs-on: ${{matrix.os}} 
     
     defaults:
@@ -57,8 +59,9 @@ jobs:
           conda info
 
           conda create -y -n "$CONDA_TEST_ENV"
-          conda install --name "$CONDA_TEST_ENV" npg_qc_utils
-          conda install --name "$CONDA_TEST_ENV" baton
+          conda install -y -n "$CONDA_TEST_ENV" nodejs=="${{ matrix.node }}"
+          conda install -y -n "$CONDA_TEST_ENV" npg_qc_utils
+          conda install -y -n "$CONDA_TEST_ENV" baton
           conda activate "$CONDA_TEST_ENV"
       env:
         CONDA_CHANNEL: https://dnap.cog.sanger.ac.uk/npg/conda/devel/generic
@@ -71,25 +74,25 @@ jobs:
     - name: Run install scripts
       run: |
           echo "$HOME/miniconda/samtools/bin" >> $GITHUB_PATH 
-          ${GITHUB_WORKSPACE}/scripts/before_install.sh $NODE_VERSION $NPM_VERSION
+          ${GITHUB_WORKSPACE}/scripts/before_install.sh $NPM_VERSION
           cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
           ${GITHUB_WORKSPACE}/scripts/install.sh $WTSI_NPG_BUILD_BRANCH $WTSI_NPG_GITHUB_URL 
-      env: 
-        NODE_VERSION: "6.12.2"
+      env:
         NPM_VERSION: "4.5.0"
         WTSI_NPG_BUILD_BRANCH: ${GITHUB_HEAD_REF} 
         WTSI_NPG_GITHUB_URL: https://github.com/wtsi-npg
 
     - name: run script
       run: |
+          export PATH="$HOME/.npm-global/bin:$PATH"
           export PATH="$HOME/miniconda/bin:$PATH"
           conda activate "$CONDA_TEST_ENV" 
           conda info --envs
           cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
-          ${GITHUB_WORKSPACE}/scripts/script.sh $NODE_VERSION $WTSI_NPG_BUILD_BRANCH
+          ${GITHUB_WORKSPACE}/scripts/script.sh "${{ matrix.node }}" $WTSI_NPG_BUILD_BRANCH
       env:
         CONDA_TEST_ENV: test-environment
-        NODE_VERSION: "6.12.2"
+        NODE_VERSION: ${{ matrix.node }}
         WTSI_NPG_BUILD_BRANCH: ${GITHUB_HEAD_REF}
 
     # Archive logs if failure

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -3,12 +3,11 @@
 set -e -x
 # set -u fails cause npm install to fail
 
-#Passing in node and npm version
-NODE_VERSION=$1
-NPM_VERSION=$2
+#Passing in npm version
+NPM_VERSION=$1
 
-# shellcheck source=/dev/null
-rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (pushd ~/.nvm && git checkout v0.31.0 && popd) && source ~/.nvm/nvm.sh && nvm install "${NODE_VERSION}"
+mkdir "$HOME/.npm-global"
+npm config set prefix "$HOME/.npm-global"
 
 npm install -g "npm@${NPM_VERSION}"
 

--- a/scripts/before_install.sh
+++ b/scripts/before_install.sh
@@ -6,9 +6,6 @@ set -e -x
 #Passing in npm version
 NPM_VERSION=$1
 
-mkdir "$HOME/.npm-global"
-npm config set prefix "$HOME/.npm-global"
-
 npm install -g "npm@${NPM_VERSION}"
 
 # Dummy executable files generated for tests use #!/usr/local/bin/bash


### PR DESCRIPTION
There is not much choice of Node.js versions in the Conda defaults channel. I've used the only one that is LTS (EOL 2023-04-30)