### PR TITLE
reformat package.json

### DIFF
--- a/npg_qc_viewer/package.json
+++ b/npg_qc_viewer/package.json
@@ -1,26 +1,26 @@
 {
-  "name":     "npg_qc_viewer",
-  "version":  "61.0.0",
+  "name": "npg_qc_viewer",
+  "version": "61.0.0",
   "homepage": "https://github.com/wtsi-npg/npg_qc",
-  "license":  "GPL-3.0+",
-  "private":  true,
+  "license": "GPL-3.0+",
+  "private": true,
   "scripts": {
     "test": "t/client/run_js_tests.sh"
   },
   "repository": {
     "type": "git",
-    "url":  "https://github.com/wtsi-npg/npg_qc.git"
+    "url": "https://github.com/wtsi-npg/npg_qc.git"
   },
-  "devDependencies" : {
+  "devDependencies": {
     "bower": "1.8.8",
-    "grunt":                 ">=1.3.0",
-    "grunt-cli":             "1.2.0",
-    "load-grunt-tasks":      "3.5.0",
-    "grunt-contrib-watch":   "1.0.0",
-    "grunt-contrib-jshint":  "1.0.0",
-    "grunt-contrib-qunit":   "1.2.0",
-    "grunt-jsonlint":        "1.0.7",
-    "grunt-jscs":            "2.8.0",
+    "grunt": ">=1.3.0",
+    "grunt-cli": "1.2.0",
+    "load-grunt-tasks": "3.5.0",
+    "grunt-contrib-watch": "1.0.0",
+    "grunt-contrib-jshint": "1.0.0",
+    "grunt-contrib-qunit": "1.2.0",
+    "grunt-jsonlint": "1.0.7",
+    "grunt-jscs": "2.8.0",
     "node-qunit-phantomjs": "1.4.0"
   }
 }


### PR DESCRIPTION
New versions of NPM reformat the file automatically. Perl generates a dirty tag
for the version if the file is not committed with the expected format applied
beforehand.