### PR TITLE
Remove dependency on npg_common::sequence::reference::base_count

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -83,7 +83,6 @@ my $requires = {
                 'npg_common::Alignment'                    => 0,
                 'npg_common::extractor::fastq'             => 0,
                 'npg_common::roles::software_location'     => 0,
-                'npg_common::sequence::reference::base_count'  => 0,
                 'npg_tracking::data::reference::list'      => 0,
                 'npg_tracking::data::bait::find'           => 0,
                 'npg_tracking::data::geno_refset::find'    => 0,

--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
  - switch to node 14 for CI, using npm from default conda pkg
+ - remove dependency on npg_common::sequence::reference::base_count, which
+   has been moved to an internal repository and is no longer available for
+   teh CI builds
 
 release 69.6.1
  - mqc skipper bug fix - inspect qc outcomes for review autoqc results


### PR DESCRIPTION
The package has been moved to an internal git repository and is no
longer available for the CI builds.

Resolves https://github.com/wtsi-npg/npg_qc/issues/757