### PR TITLE
Ability to set and save information about the pp url.     

### DIFF
--- a/lib/npg_qc/autoqc/checks/generic.pm
+++ b/lib/npg_qc/autoqc/checks/generic.pm
@@ -69,6 +69,19 @@ has 'pp_version' => (
   required => 0,
 );
 
+=head2 pp_repo_url
+
+Repository URL for the portable pipeline that produced input data for
+this check, an optional attribute.
+
+=cut
+
+has 'pp_repo_url' => (
+  isa      => 'Str',
+  is       => 'ro',
+  required => 0,
+);
+
 =head2 result
 
 This attribute is inherited from the parent and is changed to be
@@ -205,8 +218,9 @@ sub file_name2result {
 
 =head2 set_common_result_attrs
 
-Sets the check name and version and pipeline name and version
-information of the result object.
+Sets the check name and version information for the argument result object.
+If the class of the result object is 'generic', sets pipeline name, version
+and repository url information of the result object.
 
 =cut
 
@@ -218,7 +232,8 @@ sub set_common_result_attrs {
   if ($result->class_name eq 'generic') {
     my @versions = grep { defined and ($_ ne q[]) }
                    ($self->pp_version, $version_extra);
-    $result->set_pp_info($self->pp_name, join q[ ], @versions);
+    my $version = @versions ? join q[ ], @versions : q[];
+    $result->set_pp_info($self->pp_name, $version, $self->pp_repo_url);
   }
 
   return;
@@ -332,7 +347,7 @@ Marina Gourtovaia
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2020 Genome Research Ltd.
+Copyright (C) 2020,2021 Genome Research Ltd.
 
 This file is part of NPG.
 

--- a/lib/npg_qc/autoqc/results/generic.pm
+++ b/lib/npg_qc/autoqc/results/generic.pm
@@ -23,7 +23,7 @@ has 'doc' =>  (
 );
 
 sub set_pp_info {
-  my ($self, $pp_name, $pp_version) = @_;
+  my ($self, $pp_name, $pp_version, $pp_url) = @_;
 
   $pp_name or croak 'Portable pipeline name is required';
   if ($self->pp_name and ($self->pp_name ne $pp_name)) {
@@ -32,7 +32,12 @@ sub set_pp_info {
 
   $self->pp_name($pp_name);
   $self->set_info('Pipeline_name', $pp_name);
-  $pp_version && $self->set_info('Pipeline_version', $pp_version);
+  if (defined $pp_version and ($pp_version ne q[])) {
+    $pp_version and $self->set_info('Pipeline_version', $pp_version);
+  }
+  if ($pp_url) {
+    $self->set_info('Pipeline_repo_url', $pp_url);
+  }
 
   return;
 }
@@ -77,10 +82,21 @@ saved either to a file or to a datababase.
 
 =head2 set_pp_info
 
-Given the name and, optionally, version, of the portable pipeline that
-produced the data, this method sets relevant attributes of the object.
+Given the name, version, and the source repository URL of the portable
+pipeline that produced the data, this method sets some key-value pairs of the
+C<info> attribute of the object. The C<pp_name> attribute of the object is
+also set, unless there is a mismatch with an alredy available value, in which
+case an error is raised.
+
+The version and URL attributes are optional. If the version is not known, but
+the URL is, the version should be passed explicitly as an empty string. This
+empty string will not be used to set the one of the keys of the C<info>
+attribute, it will just guarantee that the the arguments are correctly
+interpreted. 
 
   $obj->set_pp_info('some_name', 'some_version');
+  $obj->set_pp_info('some_name', 'some_version', 'some_url');
+  $obj->set_pp_info('some_name', q[], 'some_url');
   $obj->set_pp_info('some_name');
 
 =head1 DIAGNOSTICS
@@ -109,7 +125,7 @@ Marina Gourtovaia
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2020 Genome Research Ltd.
+Copyright (C) 2020, 2021 Genome Research Ltd.
 
 This file is part of NPG.
 

--- a/t/60-autoqc-checks-generic-artic.t
+++ b/t/60-autoqc-checks-generic-artic.t
@@ -182,12 +182,14 @@ subtest 'different types of input' => sub {
 subtest 'result objects - data capture' => sub {
   plan tests => 62;
 
+  my $url = 'https://github.com/google/it-cert-automation-practice';
   my $g = npg_qc::autoqc::checks::generic::artic->new(
             rpt_list         => '35177:2',
             input_files_glob =>
               't/data/autoqc/generic/artic/lane2/plex*/*.qc.csv',
             pp_name          => 'artic',
             pp_version       => '0.10.0',
+            pp_repo_url      => $url,
             tm_json_file     => $tm_file);
   # Artic QC summary is not available for plexes 3 and 206.
   # Tag metrics file contains data about 13 samples.
@@ -217,7 +219,8 @@ subtest 'result objects - data capture' => sub {
     Check => 'npg_qc::autoqc::checks::generic::artic',
     Check_version => $npg_qc::autoqc::checks::generic::artic::VERSION,
     Pipeline_name => 'artic',
-    Pipeline_version => '0.10.0'
+    Pipeline_version => '0.10.0',
+    Pipeline_repo_url => $url
   };
 
   my $lims = st::api::lims->new(id_run => 35177, position => 2)

--- a/t/60-autoqc-results-generic.t
+++ b/t/60-autoqc-results-generic.t
@@ -93,35 +93,56 @@ subtest 'simple attributes and methods' => sub {
 };
 
 subtest 'setting info' => sub {
-  plan tests => 14;
+  plan tests => 25;
+
+  my $url = 'https://github.com/google/it-cert-automation-practice';
 
   my $r = npg_qc::autoqc::results::generic->new(
           composition  => $c
   );
   is ($r->pp_name(), undef, 'descriptor is undefined');
-  is ($r->info->{Pipeline_name}, undef, 'pipeline name is undefined');
-  is ($r->info->{Pipeline_version}, undef, 'pipeline version is undefined');
-  $r->set_pp_info('pp1', 'v.0.1');
-  is ($r->pp_name(), 'pp1', 'descriptor available');
+  ok (!exists $r->info->{Pipeline_name}, 'pipeline name is unset');
+  ok (!exists $r->info->{Pipeline_version}, 'pipeline version is unset');
+  ok (!exists $r->info->{Pipeline_repo_url}, 'pipeline url is unset');
+
+  throws_ok { $r->set_pp_info() } qr/Portable pipeline name is required/,
+    'error if no arguments are given';
+ 
+  $r->set_pp_info('pp1');
+  is ($r->pp_name(), 'pp1', 'pp_name attribute is set');
   is ($r->check_name, 'generic pp1', 'check name');
   is ($r->info->{Pipeline_name}, 'pp1', 'pipeline name');
+  ok (!exists $r->info->{Pipeline_version}, 'pipeline version is not set');
+  ok (!exists $r->info->{Pipeline_repo_url}, 'pipeline url is unset');
+ 
+
+  $r->set_pp_info('pp1', 'v.0.1');
+  is ($r->pp_name(), 'pp1', 'pp_name attribute is set');
+  is ($r->info->{Pipeline_name}, 'pp1', 'pipeline name');
   is ($r->info->{Pipeline_version}, 'v.0.1', 'pipeline version');
+  ok (!exists $r->info->{Pipeline_repo_url}, 'pipeline url is unset');
+
+  $r->set_pp_info('pp1', 'v.0.2', $url);
+  is ($r->info->{Pipeline_name}, 'pp1', 'pipeline name');
+  is ($r->info->{Pipeline_version}, 'v.0.2', 'pipeline version');
+  is ($r->info->{Pipeline_repo_url}, $url, 'pipeline url');
 
   $r = npg_qc::autoqc::results::generic->new(
        composition => $c,
        pp_name     => 'pp1',
        doc         => {qc_pass => 'TRUE', num_aligned_reads => 3}
   );
-  is ($r->pp_name(), 'pp1', 'descriptor');
-  is ($r->info->{Pipeline_name}, undef, 'pipeline name is undefined');
-  is ($r->info->{Pipeline_version}, undef, 'pipeline version is undefined');
+  is ($r->pp_name(), 'pp1', 'pipeline name attribute is set');
+  ok (!exists $r->info->{Pipeline_name}, 'pipeline name is not set');
+  ok (!exists $r->info->{Pipeline_version}, 'pipeline version is not set');
   throws_ok { $r->set_pp_info('pp2', 'v.0.1') }
     qr/Cannot reset portable pipeline name/,
     'pipeline name cannot be reset';
-  $r->set_pp_info('pp1', 'v.0.1');
-  is ($r->pp_name(), 'pp1', 'descriptor available');
+  $r->set_pp_info('pp1', q[], $url);
+  is ($r->pp_name(), 'pp1', 'pipeline attribute is set');
   is ($r->info->{Pipeline_name}, 'pp1', 'pipeline name');
-  is ($r->info->{Pipeline_version}, 'v.0.1', 'pipeline version');
+  ok (!exists $r->info->{Pipeline_version}, 'pipeline version is not set');
+  is ($r->info->{Pipeline_repo_url}, $url, 'pipeline url');
 };
 
 1;

--- a/t/60-autoqc-results-generic.t
+++ b/t/60-autoqc-results-generic.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 2;
+use Test::More tests => 3;
 use Test::Exception;
 
 use npg_tracking::glossary::composition;
@@ -8,31 +8,24 @@ use npg_tracking::glossary::composition::component::illumina;
 
 use_ok ('npg_qc::autoqc::results::generic');
 
-subtest 'attributes and methods' => sub {
-  plan tests => 27;
-
-  my $c = npg_tracking::glossary::composition->new(components => [
+my $c = npg_tracking::glossary::composition->new(
+  components => [
     npg_tracking::glossary::composition::component::illumina->new(
       id_run => 3, position => 1, tag_index => 4)
   ]);
+
+subtest 'simple attributes and methods' => sub {
+  plan tests => 15;
 
   my $r = npg_qc::autoqc::results::generic->new(
               composition  => $c
   );
   isa_ok ($r, 'npg_qc::autoqc::results::generic');
   is ($r->pp_name(), undef, 'descriptor is undefined');
-  is ($r->info->{Pipeline_name}, undef, 'pipeline name is undefined');
-  is ($r->info->{Pipeline_version}, undef, 'pipeline version is undefined');
   is ($r->doc(), undef, 'doc is undefined');
   is ($r->filename_root, '3_1#4.unknown', 'file name root');
   is ($r->class_name, 'generic', 'class name');
   is ($r->check_name, 'generic unknown', 'check name');
-
-  $r->set_pp_info('pp1', 'v.0.1');
-  is ($r->pp_name(), 'pp1', 'descriptor available');
-  is ($r->check_name, 'generic pp1', 'check name');
-  is ($r->info->{Pipeline_name}, 'pp1', 'pipeline name');
-  is ($r->info->{Pipeline_version}, 'v.0.1', 'pipeline version');
   $r->doc({}); # Can always be expected to be set
   is_deeply ($r->massage_for_render, {}, 'No doc, no data for render');
 
@@ -48,16 +41,6 @@ subtest 'attributes and methods' => sub {
   is ($r->filename_root, '3_1#4.pp1', 'file name root');
   is ($r->class_name, 'generic', 'class name');
   is ($r->check_name, 'generic pp1', 'check name');
-  is ($r->info->{Pipeline_name}, undef, 'pipeline name is undefined');
-  is ($r->info->{Pipeline_version}, undef, 'pipeline version is undefined');
-
-  throws_ok { $r->set_pp_info('pp2', 'v.0.1') }
-    qr/Cannot reset portable pipeline name/,
-    'pipeline name cannot be reset';
-  $r->set_pp_info('pp1', 'v.0.1');
-  is ($r->pp_name(), 'pp1', 'descriptor available');
-  is ($r->info->{Pipeline_name}, 'pp1', 'pipeline name');
-  is ($r->info->{Pipeline_version}, 'v.0.1', 'pipeline version');
 
   $r->doc({
     'QC summary' => {
@@ -107,6 +90,38 @@ subtest 'attributes and methods' => sub {
     },
     'Formatting negative control with no QC summary'
   );
+};
+
+subtest 'setting info' => sub {
+  plan tests => 14;
+
+  my $r = npg_qc::autoqc::results::generic->new(
+          composition  => $c
+  );
+  is ($r->pp_name(), undef, 'descriptor is undefined');
+  is ($r->info->{Pipeline_name}, undef, 'pipeline name is undefined');
+  is ($r->info->{Pipeline_version}, undef, 'pipeline version is undefined');
+  $r->set_pp_info('pp1', 'v.0.1');
+  is ($r->pp_name(), 'pp1', 'descriptor available');
+  is ($r->check_name, 'generic pp1', 'check name');
+  is ($r->info->{Pipeline_name}, 'pp1', 'pipeline name');
+  is ($r->info->{Pipeline_version}, 'v.0.1', 'pipeline version');
+
+  $r = npg_qc::autoqc::results::generic->new(
+       composition => $c,
+       pp_name     => 'pp1',
+       doc         => {qc_pass => 'TRUE', num_aligned_reads => 3}
+  );
+  is ($r->pp_name(), 'pp1', 'descriptor');
+  is ($r->info->{Pipeline_name}, undef, 'pipeline name is undefined');
+  is ($r->info->{Pipeline_version}, undef, 'pipeline version is undefined');
+  throws_ok { $r->set_pp_info('pp2', 'v.0.1') }
+    qr/Cannot reset portable pipeline name/,
+    'pipeline name cannot be reset';
+  $r->set_pp_info('pp1', 'v.0.1');
+  is ($r->pp_name(), 'pp1', 'descriptor available');
+  is ($r->info->{Pipeline_name}, 'pp1', 'pipeline name');
+  is ($r->info->{Pipeline_version}, 'v.0.1', 'pipeline version');
 };
 
 1;


### PR DESCRIPTION
    Extended set_pp_info() method in npg_qc::autoqc::results::generic.
    Added an optional third argument - portable pipewline repository URL,
    which is saved in the object's info attribute.
    
    Added an optional attribute pp_url to npg_qc::autoqc::checks::generic.
    Extended the set_common_result_attrs() of the check object to pass
    the value of the new attribute to the generic result object.