### PR TITLE
mqc skipper - a generic way to disregard spiked-in controls

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
+ - mqc skipper - a more generic way to disregard spiked-in controls when
+   counting the number of studies the samples in the run belong to. The change
+   is driven by the fact that spiked-in controls can now belong to a number of
+   different studies.
+
 release 69.7.0
  - added new npg_subtitution_metrics.pl script
  - move from Travis CI to GitHub Actions

--- a/bin/npg_mqc_skipper
+++ b/bin/npg_mqc_skipper
@@ -19,7 +19,7 @@ use npg_qc::mqc::skipper;
 
 our $VERSION = '0';
 
-Readonly::Scalar my $EXCLUDE_STUDY_NAME   => 'Illumina Controls';
+Readonly::Scalar my $EXCLUDE_ENTITY_TYPE  => 'library_indexed_spike';
 Readonly::Scalar my $NUM_DISTINCT_STUDIES => 1;
 Readonly::Scalar my $RUN_STATUS_FROM      => 'qc review pending';
 Readonly::Scalar my $RUN_STATUS_TO        => 'archival pending';
@@ -39,7 +39,7 @@ GetOptions('dry_run|dry-run!' => \$dry_run,
            'study_name=s'     => \$study_name,
            'deplexing_percent_threshold=i' => \$deplexing_threshold,
            'qc_fails_percent_threshold=i'  => \$qc_fails_threshold,
-	   'artic_qc_fails_percent_threshold=i'  => \$artic_qc_fails_threshold,
+           'artic_qc_fails_percent_threshold=i'  => \$artic_qc_fails_threshold,
            'help'             => sub {
              pod2usage(-verbose => 2,
                        -exitval => 0)
@@ -71,7 +71,7 @@ my @rows = $tracking_schema->resultset('Run')->search(
    'run_status_dict.description' => $RUN_STATUS_FROM,
    'instrument_format.model'     => $INSTRUMENT_MODEL},
   {prefetch => [{'run_statuses' => 'run_status_dict'}, 'instrument_format']}
-							   )->all();
+                                                     )->all();
 @rows = grep { my $row = $_; none { $row->is_tag_set($_) } @NO_SKIPPING_TAGS }
         @rows;
 
@@ -107,13 +107,13 @@ my $query =
    q[from iseq_product_metrics p ] .
    q[join iseq_flowcell f on p.id_iseq_flowcell_tmp=f.id_iseq_flowcell_tmp ] .
    q[join study s on s.id_study_tmp=f.id_study_tmp ] .
-  qq[where s.name != ? and p.id_run in (${placeholders}) ] .
+  qq[where f.entity_type != ? and p.id_run in (${placeholders}) ] .
    q[group by p.id_run having study_count = ?];
 my $sth = $dbh->prepare($query) or
   ($logger->fatal("Failed to prepare statement: $DBI::errstr") and exit 1);
 # Run time database errors are thrown by the execute method, no need to
 # do anything special.
-$sth->execute($EXCLUDE_STUDY_NAME, @run_ids, $NUM_DISTINCT_STUDIES);
+$sth->execute($EXCLUDE_ENTITY_TYPE, @run_ids, $NUM_DISTINCT_STUDIES);
 @run_ids = $get_run_ids->($sth);
 
 if (@run_ids) {


### PR DESCRIPTION
Use entity_type in the iseq_flowcell table to exclude spiked-in
controls. The change is driven by the fact that spiked-in controls
can now belong to a number of different studies.

Achieves the same result as https://github.com/wtsi-npg/npg_qc/pull/773, but is more generic