### PR TITLE
Archive QC data for runs with large number of reads.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
+ - Change database column type from unsigned int to insigned bigint
+   for columns where we store number of reads and similar values and
+   where we do not already set type to bigint. Some NovaSeq runs produce
+   more data than we envisaged when these tables were set up.
 
 release 69.8.1
  - bug fix npg_substitution_metrics.pl to not bail on single read data

--- a/lib/npg_qc/Schema/Result/Adapter.pm
+++ b/lib/npg_qc/Schema/Result/Adapter.pm
@@ -102,13 +102,13 @@ A foreign key referencing the id_seq_composition column of the seq_composition t
 
 =head2 forward_fasta_read_count
 
-  data_type: 'integer'
+  data_type: 'bigint'
   extra: {unsigned => 1}
   is_nullable: 1
 
 =head2 forward_contaminated_read_count
 
-  data_type: 'integer'
+  data_type: 'bigint'
   extra: {unsigned => 1}
   is_nullable: 1
 
@@ -124,13 +124,13 @@ A foreign key referencing the id_seq_composition column of the seq_composition t
 
 =head2 reverse_fasta_read_count
 
-  data_type: 'integer'
+  data_type: 'bigint'
   extra: {unsigned => 1}
   is_nullable: 1
 
 =head2 reverse_contaminated_read_count
 
-  data_type: 'integer'
+  data_type: 'bigint'
   extra: {unsigned => 1}
   is_nullable: 1
 
@@ -192,17 +192,17 @@ __PACKAGE__->add_columns(
   'reverse_read_filename',
   { data_type => 'varchar', is_nullable => 1, size => 256 },
   'forward_fasta_read_count',
-  { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 1 },
+  { data_type => 'bigint', extra => { unsigned => 1 }, is_nullable => 1 },
   'forward_contaminated_read_count',
-  { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 1 },
+  { data_type => 'bigint', extra => { unsigned => 1 }, is_nullable => 1 },
   'forward_blat_hash',
   { data_type => 'text', is_nullable => 1 },
   'forward_start_counts',
   { data_type => 'text', is_nullable => 1 },
   'reverse_fasta_read_count',
-  { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 1 },
+  { data_type => 'bigint', extra => { unsigned => 1 }, is_nullable => 1 },
   'reverse_contaminated_read_count',
-  { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 1 },
+  { data_type => 'bigint', extra => { unsigned => 1 }, is_nullable => 1 },
   'reverse_blat_hash',
   { data_type => 'text', is_nullable => 1 },
   'reverse_start_counts',
@@ -280,8 +280,8 @@ __PACKAGE__->belongs_to(
 with 'npg_qc::Schema::Composition', 'npg_qc::Schema::Flators', 'npg_qc::autoqc::role::result', 'npg_qc::autoqc::role::adapter';
 
 
-# Created by DBIx::Class::Schema::Loader v0.07047 @ 2017-09-14 16:25:18
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:qBi6HgQ59WjoyG18q6NmVA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-08-19 12:16:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:jxMC400VgMoWLi7VZ1BQvg
 
 our $VERSION = '0';
 

--- a/lib/npg_qc/Schema/Result/QXYield.pm
+++ b/lib/npg_qc/Schema/Result/QXYield.pm
@@ -120,37 +120,37 @@ A foreign key referencing the id_seq_composition column of the seq_composition t
 
 =head2 yield1
 
-  data_type: 'integer'
+  data_type: 'bigint'
   extra: {unsigned => 1}
   is_nullable: 1
 
 =head2 yield2
 
-  data_type: 'integer'
+  data_type: 'bigint'
   extra: {unsigned => 1}
   is_nullable: 1
 
 =head2 yield1_q30
 
-  data_type: 'integer'
+  data_type: 'bigint'
   extra: {unsigned => 1}
   is_nullable: 1
 
 =head2 yield2_q30
 
-  data_type: 'integer'
+  data_type: 'bigint'
   extra: {unsigned => 1}
   is_nullable: 1
 
 =head2 yield1_q40
 
-  data_type: 'integer'
+  data_type: 'bigint'
   extra: {unsigned => 1}
   is_nullable: 1
 
 =head2 yield2_q40
 
-  data_type: 'integer'
+  data_type: 'bigint'
   extra: {unsigned => 1}
   is_nullable: 1
 
@@ -208,17 +208,17 @@ __PACKAGE__->add_columns(
   'threshold_yield2',
   { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 1 },
   'yield1',
-  { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 1 },
+  { data_type => 'bigint', extra => { unsigned => 1 }, is_nullable => 1 },
   'yield2',
-  { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 1 },
+  { data_type => 'bigint', extra => { unsigned => 1 }, is_nullable => 1 },
   'yield1_q30',
-  { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 1 },
+  { data_type => 'bigint', extra => { unsigned => 1 }, is_nullable => 1 },
   'yield2_q30',
-  { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 1 },
+  { data_type => 'bigint', extra => { unsigned => 1 }, is_nullable => 1 },
   'yield1_q40',
-  { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 1 },
+  { data_type => 'bigint', extra => { unsigned => 1 }, is_nullable => 1 },
   'yield2_q40',
-  { data_type => 'integer', extra => { unsigned => 1 }, is_nullable => 1 },
+  { data_type => 'bigint', extra => { unsigned => 1 }, is_nullable => 1 },
   'pass',
   { data_type => 'tinyint', is_nullable => 1 },
   'comments',
@@ -292,8 +292,8 @@ __PACKAGE__->belongs_to(
 with 'npg_qc::Schema::Composition', 'npg_qc::Schema::Flators', 'npg_qc::autoqc::role::result', 'npg_qc::autoqc::role::qX_yield';
 
 
-# Created by DBIx::Class::Schema::Loader v0.07049 @ 2018-08-29 13:44:29
-# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:NBYWaBVvG2S3Etgm+Jj4sA
+# Created by DBIx::Class::Schema::Loader v0.07049 @ 2021-08-19 12:16:50
+# DO NOT MODIFY THIS OR ANYTHING ABOVE! md5sum:LHzBwbDWKgAAeb8bUrM8og
 
 our $VERSION = '0';
 

--- a/scripts/upgrade_schema/upgrade_schema-69.9.0
+++ b/scripts/upgrade_schema/upgrade_schema-69.9.0
@@ -1,0 +1,16 @@
+-- Change type of some columns from UNSIGNED INT to INSIGNED BIGINT
+-- to accommodate large integer values for NovaSeq data
+
+ALTER TABLE `adapter` \
+  MODIFY `forward_fasta_read_count` BIGINT UNSIGNED DEFAULT NULL, \
+  MODIFY `reverse_fasta_read_count` BIGINT UNSIGNED DEFAULT NULL, \
+  MODIFY `forward_contaminated_read_count` BIGINT UNSIGNED DEFAULT NULL, \
+  MODIFY `reverse_contaminated_read_count` BIGINT UNSIGNED DEFAULT NULL;
+
+ALTER TABLE `qx_yield` \
+  MODIFY `yield1` BIGINT UNSIGNED DEFAULT NULL, \
+  MODIFY `yield2` BIGINT UNSIGNED DEFAULT NULL, \
+  MODIFY `yield1_q30` BIGINT UNSIGNED DEFAULT NULL, \
+  MODIFY `yield2_q30` BIGINT UNSIGNED DEFAULT NULL, \
+  MODIFY `yield1_q40` BIGINT UNSIGNED DEFAULT NULL, \
+  MODIFY `yield2_q40` BIGINT UNSIGNED DEFAULT NULL;


### PR DESCRIPTION
Change database column type from unsigned int to unsigned bigint
for columns where we store number of reads and similar values and
where we do not already set type to bigint. Some NovaSeq runs
produce more data than we envisaged when these tables were set up.

The schema update will be tested on the replica of the production database
to get an idea of how long the update takes.