### PR TITLE
Bower url dependencies update

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,7 @@ release 69.11.1
      2. added a document that captures an interim projetc review.
  - bower dependencies are expressed using https urls as unauth git endpoints
    are not supported in github anymore
+ - update bower to 1.8.13
 
 release 69.11.0
  - PDL CPAN Perl package had a flurry of releases recently, the latest

--- a/Changes
+++ b/Changes
@@ -4,6 +4,8 @@ release 69.11.1
  - Normalisation of negative controls with PhiX:
      1. added a script to compute linear regression stats,
      2. added a document that captures an interim projetc review.
+ - bower dependencies are expressed using https urls as unauth git endpoints
+   are not supported in github anymore
 
 release 69.11.0
  - PDL CPAN Perl package had a flurry of releases recently, the latest

--- a/npg_qc_viewer/bower.json
+++ b/npg_qc_viewer/bower.json
@@ -3,9 +3,9 @@
   "dependencies": {
     "jquery": "2.2.3",
     "requirejs": "2.2.0",
-    "bcviz": "git://github.com/wtsi-npg/bcviz.git#1.3.3",
-    "jquery-unveil" : "git://github.com/wtsi-npg/unveil#1.3.0",
-    "table-export" : "git://github.com/hhurz/tableExport.jquery.plugin.git#v1.5.0"
+    "bcviz": "https://github.com/wtsi-npg/bcviz.git#1.3.3",
+    "jquery-unveil" : "https://github.com/wtsi-npg/unveil.git#1.3.0",
+    "table-export" : "https://github.com/hhurz/tableExport.jquery.plugin.git#v1.5.0"
   },
   "devDependencies": {
     "qunit": "1.23.0",

--- a/npg_qc_viewer/package.json
+++ b/npg_qc_viewer/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/wtsi-npg/npg_qc.git"
   },
   "devDependencies": {
-    "bower": "1.8.8",
+    "bower": "1.8.13",
     "grunt": ">=1.3.0",
     "grunt-cli": "1.2.0",
     "load-grunt-tasks": "3.5.0",


### PR DESCRIPTION
Github dropped support for unauthenticated git protocol pulls, [see](https://web.archive.org/web/20220322001054/https://github.blog/2021-09-01-improving-git-protocol-security-github/).

The change seems was final on 20220315, so we would need to change those git urls to https equivalents to be able to pull from the repos without authenticating.