### PR TITLE
QC View sorting order to put merged lanes before unmerged.

### DIFF
--- a/lib/npg_qc/autoqc/role/rpt_key.pm
+++ b/lib/npg_qc/autoqc/role/rpt_key.pm
@@ -85,7 +85,7 @@ operation on the list. A single hash reference is returned.
             'id_run' => '1',
             'position' => '2-3',
             'tag_index' => '3'
-          }; 
+          };
 
 =cut
 sub rpt_list2one_hash {
@@ -161,8 +161,24 @@ sub _compare_rpt_keys_zero_last {
     my $b_map = __PACKAGE__->rpt_list2one_hash($b);
 
     return $a_map->{'id_run'} cmp $b_map->{'id_run'} ||
-           $a_map->{'position'} cmp $b_map->{'position'} ||
+           _compare_position($a_map->{'position'}, $b_map->{'position'}) ||
            _compare_tags_zero_last($a_map, $b_map);
+}
+
+sub _compare_position {## no critic (RequireArgUnpacking)
+  # Look for - indicating merged positions. Put merges first
+  my $a_merged = $_[0] =~ /[-]/xms;
+  my $b_merged = $_[1] =~ /[-]/xms;
+
+  if ($a_merged && $b_merged) {
+    return $_[0] cmp $_[1];
+  } elsif ($a_merged) {
+    return $LESS;
+  } elsif ($b_merged) {
+    return $MORE;
+  } else {
+    return $_[0] <=> $_[1]; # position is purely numeric
+  }
 }
 
 sub _compare_tags_zero_last {## no critic (RequireArgUnpacking)
@@ -256,10 +272,11 @@ __END__
 =head1 AUTHOR
 
 Marina Gourtovaia E<lt>mg8@sanger.ac.ukE<gt>
+Kieron Taylor E<lt>kt19@sanger.ac.ukE<gt>
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2018 GRL
+Copyright (C) 2018, 2023 GRL
 
 This file is part of NPG.
 

--- a/t/60-autoqc-role-rpt_key.t
+++ b/t/60-autoqc-role-rpt_key.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More tests => 3;
+use Test::More tests => 5;
 
 use_ok('npg_qc::autoqc::role::rpt_key');
 
@@ -16,6 +16,37 @@ subtest 'first rpt key of the rpt lists' => sub {
   is (npg_qc::autoqc::role::rpt_key->rpt_list2first_rpt_key('5:1'), '5:1');
   is (npg_qc::autoqc::role::rpt_key->rpt_list2first_rpt_key('5:1:2'), '5:1:2');
   is (npg_qc::autoqc::role::rpt_key->rpt_list2first_rpt_key('5:1:2:5:3:4'), '5:1:2');
+};
+
+subtest 'Unpacking composite RPT strings' => sub {
+  plan tests => 1;
+  is_deeply(
+    npg_qc::autoqc::role::rpt_key->rpt_list2one_hash('1:1:1;1:2:1'),
+    {
+      id_run => '1',
+      position => '1-2',
+      tag_index => '1'
+    },
+    'Composite RPT is turned into a combined object'
+  );
+};
+
+subtest 'Sorting of lane positions and tag indexes in the /checks/runs library lane view' => sub {
+  plan tests => 7;
+
+  my $rpt_tests = [
+    [['1:1:888'], ['1:1:888'], 'One in, one out'],
+    [['1:1:0', '1:1:1', '1:1:2'], ['1:1:1', '1:1:2', '1:1:0'], 'All-numeric RPTs are sorted, tag 0 last'],
+    [['1:20:10', '1:1:9', '1:2:8'], ['1:1:9', '1:2:8', '1:20:10'], 'Positions are sorted numerically over tags'],
+    [['1:5:1', '2:1:0', '3:8:888'], ['1:5:1', '2:1:0', '3:8:888'], 'Lanes always win'],
+    [['1:1:0', '1:1:1;1:2:1;1:3:1'], ['1:1:1;1:2:1;1:3:1', '1:1:0'], 'Position ranges are sorted first'],
+    [['1:1:1;1:2:1;1:3:1', '1:1:0'], ['1:1:1;1:2:1;1:3:1', '1:1:0'], 'Position ranges are sorted first'],
+    [['1:1:0', '1:1:1;1:2:1', '1:1:888'], ['1:1:1;1:2:1', '1:1:888', '1:1:0'], 'Merge first, then high tag, then zero']
+  ];
+
+  foreach my $rpt (@$rpt_tests) {
+    is_deeply([npg_qc::autoqc::role::rpt_key->sort_rpt_keys_zero_last($rpt->[0])], $rpt->[1], $rpt->[2]);
+  }
 };
 
 1;


### PR DESCRIPTION
Actively sort merged-lane RPTs ahead of plain RTS to stop tag zero bubbling to the top when merges are present in a run.