### PR TITLE
rna seq qc max memory increased to 8GB

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,7 @@ LIST OF CHANGES FOR NPG-QC PACKAGE
    result can be loaded to the database without problems.
  - Updated the SeqQC summary display for pulldown_metrics incomplete results
    so that just 'n/a' is displayed.
+ - autoqc rna seqqc max memory hardcoded limit increased to 8000MB
 
 release 72.0.0
 

--- a/lib/npg_qc/autoqc/checks/rna_seqc.pm
+++ b/lib/npg_qc/autoqc/checks/rna_seqc.pm
@@ -302,7 +302,7 @@ sub _command {
     if($self->ref_rrna){
         $ref_rrna_option = q[-bwa ] . $self->bwa_rrna . q[ -BWArRNA ]. $self->ref_rrna;
     }
-    my $command = $self->java_cmd. sprintf q[ -Xmx4000m -XX:+UseSerialGC -XX:-UsePerfData -jar %s -s %s -o %s -r %s -t %s -ttype %d %s %s],
+    my $command = $self->java_cmd. sprintf q[ -Xmx8000m -XX:+UseSerialGC -XX:-UsePerfData -jar %s -s %s -o %s -r %s -t %s -ttype %d %s %s],
                                            $self->_java_jar_path,
                                            $self->_input_str,
                                            $self->rna_seqc_report_path,


### PR DESCRIPTION
Small fix until we add an argument for the check to control the number.