### PR TITLE
Fixed the SeqQC pulldown metrics display bug

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,6 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
-release 72.0.2
- - Fixed the bug that was intruduced while updating the SeqQC summary display
+ - Fixed the bug that was introduced while updating the SeqQC summary display
    for pulldown_metrics incomplete results. The bug manifestation is a display
    appearence of an unexpected raw mean depth value just before the coverage
    value. All values that should be displayed were unaffected by the bug.

--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 LIST OF CHANGES FOR NPG-QC PACKAGE
 
+release 72.0.2
+ - Fixed the bug that was intruduced while updating the SeqQC summary display
+   for pulldown_metrics incomplete results. The bug manifestation is a display
+   appearence of an unexpected raw mean depth value just before the coverage
+   value. All values that should be displayed were unaffected by the bug.
+
 release 72.0.1
  - Ensured that retrieving values from a partially defined pulldown_metrics
    result does not trigger an error. Added a test to demonstrate that such

--- a/npg_qc_viewer/root/src/ui_lanes/lane.tt2
+++ b/npg_qc_viewer/root/src/ui_lanes/lane.tt2
@@ -439,7 +439,7 @@ END
     END;
     coverage = result.target_bases_coverage_percent.20 ? result.target_bases_coverage_percent.20 : 0; 
 -%]
-[% IF mcoverage > 0 %]
+[% IF mcoverage >= 0 %]
 [% IF result.interval_files_identical.defined && result.interval_files_identical == 1 %]
 <span class="pdmc_na" title="Bait and target intervals identical"><a href="[% href %]">NA&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;NA<br/></a></span>
 <span class="dark_blue" title="On-bait bases %age"><a href="[% href %]">[% FILTER format('%2.2f');on_bait;END %]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</a></span>

--- a/npg_qc_viewer/root/src/ui_lanes/lane.tt2
+++ b/npg_qc_viewer/root/src/ui_lanes/lane.tt2
@@ -425,7 +425,7 @@ END
 [% href='#pdmc_' _ result.id_run _ ':' _ result.position _ ':' _ result.tag_index %]
 
 [%- 
-    mcoverage;
+    mcoverage = -1;
     IF result.unique_bases_aligned_num.defined && result.unique_bases_aligned_num != 0;
       mcoverage = result.mean_target_coverage / (result.unique_bases_aligned_num / 1000000000);
     END;
@@ -439,7 +439,7 @@ END
     END;
     coverage = result.target_bases_coverage_percent.20 ? result.target_bases_coverage_percent.20 : 0; 
 -%]
-[% IF mcoverage.defined %]
+[% IF mcoverage > 0 %]
 [% IF result.interval_files_identical.defined && result.interval_files_identical == 1 %]
 <span class="pdmc_na" title="Bait and target intervals identical"><a href="[% href %]">NA&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;NA<br/></a></span>
 <span class="dark_blue" title="On-bait bases %age"><a href="[% href %]">[% FILTER format('%2.2f');on_bait;END %]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</a></span>


### PR DESCRIPTION
The was intruduced while updating the SeqQC summary display for pulldown_metrics incomplete results. The bug manifestation is a display appearence of an
unexpected raw mean depth value just before the coverage value.