### PR TITLE
Provide a script that can convert Elembio RunStats.json files into tag_metrics objects

### DIFF
--- a/bin/elembio_runstats_parser.pl
+++ b/bin/elembio_runstats_parser.pl
@@ -1,0 +1,158 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use FindBin qw($Bin);
+use lib ( -d "$Bin/../lib/perl5" ? "$Bin/../lib/perl5" : "$Bin/../lib" );
+
+use Getopt::Long;
+use JSON;
+
+use npg_qc::autoqc::results::tag_metrics;
+use npg_qc::elembio::run_stats;
+
+our $VERSION = '0';
+
+sub get_options {
+
+  my $usage = q[
+
+  Usage:
+          elembio_qc_converter.pl <opts>
+          perl bin/elembio_runstats_parser.pl --input /lustre/scratch120/npg/elembio_deplex/20250509_AV244103_NT1854541J/20250509_AV244103_NT1854541J --output ~/elembio_parsing_tests/ --id_run 15
+
+  Options:
+         --input <dir>      Deplexing folder where RunStats.json, RunParameters.json and RunManifest.json live
+         --output <dir>     Where to put the transformed tag_metrics outputs
+         --id_run <int>     Supply an id_run from npg_tracking
+         -h                 help
+
+  ];
+
+  my %options = (verbose => 0);
+
+  my $result = GetOptions(\%options,
+                          'input:s',
+                          'output:s',
+                          'id_run:i',
+                          'verbose',
+                          'help'
+                          );
+
+  die "$usage\n" if( !$result || $options{help});
+
+  return \%options;
+}
+
+sub main {
+    my $opts = get_options();
+
+    my $deplex_folder = $opts->{'input'};
+
+    my $run_stats = npg_qc::elembio::run_stats::run_stats_from_file($deplex_folder.'/RunStats.json', $deplex_folder.'/RunManifest.json');
+
+    # Where do we get an id_run from? Argument for now. $runstats->{'RunName'} is non-numeric.
+    # Waiting for a script.
+
+    while (my($lane, $lane_stats) = each %{$run_stats->lanes}) {
+        my $metrics_obj = npg_qc::autoqc::results::tag_metrics->new(
+            id_run => $opts->{'id_run'},
+            position => $lane,
+        );
+        foreach my $sample ($lane_stats->all_samples()) {
+            $metrics_obj->reads_pf_count->{$sample->tag_index} = $sample->num_polonies; # ??
+            $metrics_obj->tags->{$sample->tag_index} = $sample->barcode_string();
+            # polonies before trim are equal to polonies in the source data, or so it seems
+            $metrics_obj->reads_count->{$sample->tag_index} = $sample->num_polonies;
+        }
+
+        my $output_name = sprintf '%s_%s_tag_metrics.json', $opts->{'id_run'}, $lane;
+
+        my $tag_metrics_json = $metrics_obj->freeze();
+        write_file($opts->{'output'}.$output_name, $tag_metrics_json);
+    }
+    return;
+}
+
+
+main();
+1;
+
+__END__
+
+=head1 NAME
+
+elembio_runstats_parser.pl
+
+=head1 USAGE
+
+elembio_runstats.parser.pl --input <runfolder> --output <folder> --id_run <id>
+
+=head1 CONFIGURATION
+
+=head1 SYNOPSIS
+
+=head1 DESCRIPTION
+
+Extracts lane-centric metrics from the Element BioSciences Aviti deplexing
+outputs and converts them to format amenable to NPG_QC
+
+=head1 SUBROUTINES/METHODS
+
+=head1 DIAGNOSTICS
+
+=head1 CONFIGURATION AND ENVIRONMENT
+
+=head1 REQUIRED ARGUMENTS
+
+=head1 OPTIONS
+
+=head1 EXIT STATUS
+
+=head1 DEPENDENCIES
+
+=over
+
+=item strict
+
+=item warnings
+
+=item FindBin
+
+=item Getopt::Long
+
+=item npg_qc::autoqc::results::tag_metrics
+
+=item npg_qc::elembio::run_stats
+
+=back
+
+=head1 INCOMPATIBILITIES
+
+=head1 BUGS AND LIMITATIONS
+
+=head1 AUTHOR
+
+Kieron Taylor<lt>kt19@sanger.ac.ukE<gt>
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2025 GRL, by Kieron Taylor
+
+This file is part of NPG.
+
+NPG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+=cut
+

--- a/lib/npg_qc/elembio/lane_stats.pm
+++ b/lib/npg_qc/elembio/lane_stats.pm
@@ -1,0 +1,113 @@
+package npg_qc::elembio::lane_stats;
+
+use Moose;
+use namespace::autoclean;
+use npg_qc::elembio::sample_stats;
+
+
+our $VERSION = '0';
+
+has num_polonies => (
+    isa => 'Int',
+    is => 'ro',
+    documentation => 'Effectively the number of reads from this lane',
+);
+
+has deplexed_samples => (
+    isa => 'HashRef',
+    is => 'ro',
+    init_arg => undef,
+    required => 0,
+    traits => ['Hash'],
+    handles => {
+        set_sample => 'set',
+        all_samples => 'values',
+    },
+);
+
+has total_yield => (
+    isa => 'Num',
+    is => 'ro',
+    documentation => 'Gigabase count for the lane',
+);
+
+has unassigned_reads => (
+    isa => 'Int',
+    is => 'ro',
+    documentation => 'Number of reads that were not deplexed successful',
+);
+
+has percentQ30 => (
+    isa => 'Num',
+    is => 'ro',
+);
+
+has percentQ40 => (
+    isa => 'Num',
+    is => 'ro',
+);
+
+__PACKAGE__->meta->make_immutable;
+
+1;
+
+__END__
+
+=head1 NAME
+
+npg_qc::elembio::lane_stats
+
+=head1 SYNOPSIS
+
+=head1 DESCRIPTION
+
+Represents lane stats from an Elembio bases2fastq RunStats.json file.
+It has overall statistics for the lane, and deplexed_samples attribute that
+indexes each sample found in the lane.
+
+=head1 SUBROUTINES/METHODS
+
+=head1 DIAGNOSTICS
+
+=head1 CONFIGURATION AND ENVIRONMENT
+
+=head1 DEPENDENCIES
+
+=over
+
+=item Moose
+
+=item namespace::autoclean
+
+=item npg_qc::elembio::sample_stats
+
+=back
+
+=head1 INCOMPATIBILITIES
+
+=head1 BUGS AND LIMITATIONS
+
+=head1 AUTHOR
+
+Kieron Taylor E<lt>kt19@sanger.ac.ukE<gt>
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2025 GRL
+
+This file is part of NPG.
+
+NPG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+=cut

--- a/lib/npg_qc/elembio/run_stats.pm
+++ b/lib/npg_qc/elembio/run_stats.pm
@@ -1,0 +1,242 @@
+package npg_qc::elembio::run_stats;
+
+use Moose;
+use Carp qw(croak);
+use File::Slurp qw(read_file);
+use JSON;
+use List::Util qw(uniq sum);
+use namespace::autoclean;
+use npg_qc::elembio::lane_stats;
+use npg_qc::elembio::sample_stats;
+
+
+our $VERSION = '0';
+
+# For "merged" samples, indexed by sample name
+has deplexed_samples => (
+    isa => 'HashRef[npg_qc::elembio::sample_stats]',
+    is => 'rw',
+    traits => ['Hash'],
+    handles => {
+        add_sample => 'set',
+    },
+);
+
+has lanes => (
+    traits => ['Hash'],
+    isa => 'HashRef[npg_qc::elembio::lane_stats]',
+    is => 'rw',
+    handles => {
+        get_lane => 'get',
+        set_lane => 'set',
+    },
+);
+
+has r1_cycle_count => (
+    isa => 'Int',
+    is => 'rw',
+    documentation => 'Effectively the number of bases sequenced',
+);
+
+has r2_cycle_count => (
+    isa => 'Int',
+    is => 'rw',
+    documentation => 'Effectively the number of bases sequenced',
+);
+
+__PACKAGE__->meta->make_immutable;
+
+no Moose;
+# Builder functions that create the run_stats instance with data
+
+sub run_stats_from_json {
+    my $runstats_str = shift;
+    my $manifest_str = shift;
+
+    my $data = decode_json($runstats_str);
+    my $manifest = decode_json($manifest_str);
+
+    # Make some sample objects from the manifest to be fleshed out with stats
+    # later on. The safest way to get the barcodes is via manifest.
+    my %sample_lookup;
+    foreach my $sample (@{$manifest->{Samples}}) {
+        # Establish if there is more than one index1/index2 per sample
+        # It's much more complicated to map that into npg_qc.
+        my @lanes = uniq map { $_->{Lane} } @{$sample->{Indexes}};
+        if ((@{$sample->{Indexes}}) > @lanes) {
+            croak q(More than one tag per sample per lane. It's too hard);
+        }
+
+        foreach my $lane (@lanes) {
+            my $sample_obj = npg_qc::elembio::sample_stats->new(
+                sample_name => $sample->{SampleName},
+                tag_index => int($sample->{SampleNumber}),
+            );
+            my ($tags_in_lane) = grep { $_->{Lane} == $lane } @{ $sample->{Indexes} };
+            $sample_obj->barcode([$tags_in_lane->{Index1}]);
+            if (exists $tags_in_lane->{Index2}) {
+                push @{$sample_obj->barcode} , $tags_in_lane->{Index2};
+            }
+
+            $sample_lookup{$lane}->{$sample->{SampleName}} = $sample_obj;
+        }
+    }
+
+    # For one lane, find the Reads section for R1, extract the MeanReadLength
+    # and cast to int. Then repeat for R2
+    my $run_stats = npg_qc::elembio::run_stats->new(
+        r1_cycle_count => int((grep { $_->{Read} eq 'R1' } @{$data->{Lanes}[0]{Reads}} )[0]->{MeanReadLength}),
+        r2_cycle_count => int((grep { $_->{Read} eq 'R2' } @{$data->{Lanes}[0]{Reads}} )[0]->{MeanReadLength})
+    );
+    # Add lane stats to the runstats object
+    foreach my $lane (@{$data->{Lanes}}) {
+        next if $lane->{NumPolonies} == 0;
+        my $lane_number = $lane->{Lane};
+        $run_stats->set_lane(
+            $lane_number,
+            npg_qc::elembio::lane_stats->new(
+                num_polonies => $lane->{NumPolonies},
+                total_yield => $lane->{TotalYield},
+                unassigned_reads => sum( map { $_->{Count} } @{ $lane->{UnassignedSequences} }),
+                percentQ30 => $lane->{PercentQ30},
+                percentQ40 => $lane->{PercentQ40},
+            )
+        );
+    }
+
+    # Add sample stats to the lanes
+    foreach my $sample (@{$data->{SampleStats}}) {
+        # Occurences describe the number of times a sample was found in this
+        # lane
+        foreach my $occurrence (@{$sample->{Occurrences}}) {
+            my $lane = $occurrence->{Lane};
+            next if ($occurrence->{NumPolonies} == 0);
+            # 1+2 300 cycle run appears in stats as lane 2 being full of nulls and 0's
+
+            my $laned_sample = $sample_lookup{$lane}->{$sample->{SampleName}};
+            $laned_sample->percentQ30($occurrence->{PercentQ30});
+            $laned_sample->percentQ40($occurrence->{PercentQ40});
+            $laned_sample->num_polonies($occurrence->{NumPolonies});
+            $laned_sample->yield($occurrence->{Yield});
+
+            $run_stats->lanes->{$lane}->set_sample($sample->{SampleName}, $laned_sample);
+        }
+
+        my $convenient_sample = $sample_lookup{1}->{$sample->{SampleName}};
+        my $run_sample = npg_qc::elembio::sample_stats->new(
+            sample_name => $convenient_sample->sample_name,
+            tag_index => $convenient_sample->tag_index,
+            barcode => $convenient_sample->barcode,
+            num_polonies => $sample->{NumPolonies},
+            percentQ30 => $sample->{PercentQ30},
+            percentQ40 => $sample->{PercentQ40},
+            yield => $sample->{Yield},
+        );
+
+        $run_stats->add_sample($run_sample->sample_name, $run_sample);
+    }
+    return $run_stats;
+}
+
+sub run_stats_from_file {
+    my $run_stats_file = shift;
+    my $manifest_file = shift;
+
+    my $manifest = read_file($manifest_file);
+    my $run_stats = read_file($run_stats_file);
+    return run_stats_from_json($run_stats, $manifest);
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;
+
+__END__
+
+=head1 NAME
+
+npg_qc::elembio::run_stats
+
+=head1 SYNOPSIS
+
+  use npg_qc::elembio::run_stats;
+  my $run_stats = npg_qc::elembio::run_stats::run_stats_from_file(
+    "RunStats.json",
+    "RunManifest.json"
+  );
+
+  my $lane_stats = $run_stats->get_lane('1');
+  ...
+
+=head1 DESCRIPTION
+
+Consumes a Elembio bases2fastq RunStats.json file, and slices out lanes of
+data for easy access
+
+=head1 SUBROUTINES/METHODS
+
+=head2 run_stats_from_file
+
+Accepts two filenames, one for RunStats.json and one for RunManifest.json
+It then creates a npg_qc::elembio::run_stats instance populated with the
+information found in those files.
+
+=head2 run_stats_from_json
+
+Accepts two hash-refs containing RunStats.json and RunManifest.json.
+This function exists to allow bypassing of the file-reading component.
+
+=head1 DIAGNOSTICS
+
+=head1 CONFIGURATION AND ENVIRONMENT
+
+=head1 DEPENDENCIES
+
+=over
+
+=item Moose
+
+=item Carp
+
+=item File::Slurp
+
+=item JSON
+
+=item List::Util
+
+=item namespace::autoclean
+
+=item npg_qc::elembio::lane_stats
+
+=item npg_qc::elembio::sample_stats
+
+=back
+
+=head1 INCOMPATIBILITIES
+
+=head1 BUGS AND LIMITATIONS
+
+=head1 AUTHOR
+
+Kieron Taylor E<lt>kt19@sanger.ac.ukE<gt>
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2025 GRL
+
+This file is part of NPG.
+
+NPG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+=cut

--- a/lib/npg_qc/elembio/sample_stats.pm
+++ b/lib/npg_qc/elembio/sample_stats.pm
@@ -1,0 +1,125 @@
+package npg_qc::elembio::sample_stats;
+# per-lane sample stats
+
+use Moose;
+use namespace::autoclean;
+
+
+our $VERSION = '0';
+
+# In npg_qc, AAAAAAA-TTTTTT
+# barcode => [AAAAA, TTTTTT]
+has barcode => (
+    isa => 'ArrayRef[Str]',
+    is => 'rw',
+    documentation => 'I1 and I2 sequences in order',
+);
+
+sub barcode_string {
+    my $self = shift;
+    if ( @{ $self->barcode } > 1) {
+        return join q{-}, $self->barcode->[0], $self->barcode->[1];
+    } else {
+        return $self->barcode->[0];
+    }
+}
+
+has tag_index => (
+    isa => 'Int',
+    is => 'rw',
+);
+
+has sample_name => (
+    isa => 'Str',
+    is => 'ro',
+);
+
+has percentQ30 => (
+    isa => 'Num',
+    is => 'rw',
+);
+
+has percentQ40 => (
+    isa => 'Num',
+    is => 'rw',
+);
+
+has num_polonies => (
+    isa => 'Int',
+    is => 'rw',
+);
+
+has yield => (
+    isa => 'Num',
+    is => 'rw',
+    documentation => 'Gigabases for sample',
+);
+
+__PACKAGE__->meta->make_immutable;
+
+1;
+
+__END__
+
+=head1 NAME
+
+npg_qc::elembio::sample_stats
+
+=head1 SYNOPSIS
+
+$sample->barcode_string(); # -> AAAAAAA-TTTTTTT
+
+=head1 DESCRIPTION
+
+Represents deplexed stats for sample from either all lanes, or just one.
+Populated from an Elembio bases2fastq RunStats.json file by npg_qc::elembio::run_stats.
+
+=head1 SUBROUTINES/METHODS
+
+=head2 barcode_string
+
+Generates an npg_qc compatible barcode string from the individual index reads
+stored in $self->barcode
+
+=head1 DIAGNOSTICS
+
+=head1 CONFIGURATION AND ENVIRONMENT
+
+=head1 DEPENDENCIES
+
+=over
+
+=item Moose
+
+=item namespace::autoclean
+
+=back
+
+=head1 INCOMPATIBILITIES
+
+=head1 BUGS AND LIMITATIONS
+
+=head1 AUTHOR
+
+Kieron Taylor E<lt>kt19@sanger.ac.ukE<gt>
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2025 GRL
+
+This file is part of NPG.
+
+NPG is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+=cut

--- a/t/30-elembio-runstats.t
+++ b/t/30-elembio-runstats.t
@@ -1,0 +1,12 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::Exception;
+
+use_ok('npg_qc::elembio::run_stats');
+
+my $stats = npg_qc::elembio::run_stats->new();
+
+# Insert some useful tests with realistic data?
+
+done_testing();


### PR DESCRIPTION
Lacks useful tests/data and verification that the outputted tag metrics files render reasonably in NPG_QC.