### PR TITLE
Identification of sequencing controls.

### DIFF
--- a/Changes
+++ b/Changes
@@ -13,6 +13,12 @@ LIST OF CHANGES FOR NPG-QC PACKAGE
    - A comment is added to npg_qc::autoqc::results::tag_metrics
      object to explain the above tag sequence notation if it is
      present.
+   - Control samples are identified by their name and flagged.
+     Examples: GCACATAGTC-GACTACTAGC(CTRL) or ATGTCGCTAG-CTAGCTCGTA[+3](CTRL).
+   - Where there is one control sample per lane, spiked_control_index
+     attribute of npg_qc::autoqc::results::tag_metrics object is set, making
+     calculations of the coefficient of variance and highlighting of
+     underrepresented tags more accurate.
    - More properties are set for tag zero in tag_metrics object
      to make the definition of tag zero for Elembio lanes identical
      to the one for Illumina lanes.

--- a/lib/npg_qc/elembio/sample_stats.pm
+++ b/lib/npg_qc/elembio/sample_stats.pm
@@ -3,10 +3,15 @@ package npg_qc::elembio::sample_stats;
 use Moose;
 use namespace::autoclean;
 use List::Util qw(sum);
+use Readonly;
 use npg_qc::elembio::barcode_stats;
 
 
 our $VERSION = '0';
+
+# The extended scope allows for using this regular expression
+# in other NPG code.
+Readonly::Scalar our $CONTROL_SAMPLE_NAME_REGEXP => qr/(?:adept)|(?:phix_third)/ismx;
 
 has barcodes => (
     isa => 'HashRef[npg_qc::elembio::barcode_stats]',
@@ -37,6 +42,16 @@ has sample_name => (
     isa => 'Str',
     is => 'ro',
 );
+
+has is_control => (
+    isa => 'Bool',
+    is => 'ro',
+    lazy_build => 1,
+);
+sub _build_is_control {
+    my $self = shift;
+    return $self->sample_name =~ /$CONTROL_SAMPLE_NAME_REGEXP/smx;
+}
 
 has lane => (
     isa => 'Int',
@@ -189,6 +204,8 @@ averaged result as appropriate. In gigabases.
 =item Moose
 
 =item namespace::autoclean
+
+=item Readonly
 
 =item npg_qc::elembio::barcode_stats
 

--- a/t/30-elembio-runstats.t
+++ b/t/30-elembio-runstats.t
@@ -126,8 +126,8 @@ use_ok('npg_qc::elembio::run_stats');
                     'Tag 0 virtual barcode is correct');
             } else {
                 my ($is_control) = grep {$_ == $tag_index} (1,2,3,4);
-                my $expr = $is_control ? qr/^[ATCG]{8}\(CTRL\)$/ : qr/^[ATCG]{8}$/;
-                ok($lane->tags->{$tag_index} =~ $expr,
+                like($lane->tags->{$tag_index},
+                    $is_control ? qr/^[ATCG]{8}\(CTRL\)$/ : qr/^[ATCG]{8}$/,
                     'Generated single barcodes are formatted correctly');
             }
         }

--- a/t/30-elembio-runstats.t
+++ b/t/30-elembio-runstats.t
@@ -125,11 +125,14 @@ use_ok('npg_qc::elembio::run_stats');
                 is($lane->tags->{0}, 'NNNNNNNN',
                     'Tag 0 virtual barcode is correct');
             } else {
-                ok($lane->tags->{$tag_index} =~ /^[ATCG]{8}$/,
+                my ($is_control) = grep {$_ == $tag_index} (1,2,3,4);
+                my $expr = $is_control ? qr/^[ATCG]{8}\(CTRL\)$/ : qr/^[ATCG]{8}$/;
+                ok($lane->tags->{$tag_index} =~ $expr,
                     'Generated single barcodes are formatted correctly');
             }
         }
         ok(!$lane->comments(), 'No comments');
+        is($lane->spiked_control_index, undef, 'Spiked control index is not set');
     }
 }
 


### PR DESCRIPTION
Control samples are identified by their name and flagged. Examples: GCACATAGTC-GACTACTAGC(CTRL) or
ATGTCGCTAG-CTAGCTCGTA[+3](CTRL).

Where there is one control sample per lane, spiked_control_index attribute of npg_qc::autoqc::results::tag_metrics objectis set, making calculations of the coefficient of variance and highlighting of underrepresented tags more accurate.