### PR TITLE
genotype QC check data prep: fix overdone and underdone file checks

### DIFF
--- a/bin/gtck_combine_gt_data_incremental.sh
+++ b/bin/gtck_combine_gt_data_incremental.sh
@@ -30,7 +30,13 @@ then
   exit 0
 fi
 
-if [[ -e latest_combined_file.txt ]] && cmp -s latest_processed_plex_list.txt latest_combined_file.txt
+if [[ ! -e latest_combined_file.txt ]]
+then
+  echo "Not producing new combined genotype data file - no latest_combined_file.txt"
+  exit 0
+fi
+
+if cmp -s latest_processed_plex_list.txt latest_combined_file.txt
 then
   echo "Not producing new combined genotype data file - no new data (latest_processed_plex_list.txt and latest_combined_file.txt are the same)"
   exit 0

--- a/bin/gtck_extract_incremental_fluidigm_data_from_irods.sh
+++ b/bin/gtck_extract_incremental_fluidigm_data_from_irods.sh
@@ -15,6 +15,12 @@ then
   exit 0
 fi
 
+if [[ ! -e latest_combined_file.txt ]]
+then
+  echo "Not running extract_fluidigm_data_from_irods - no latest_combined_file.txt"
+  exit 0
+fi
+
 if [[ -e latest_processed_plex_list.txt ]] && cmp -s latest_plex_list.txt latest_processed_plex_list.txt
 then
   echo "Not running extract_fluidigm_data_from_irods - no new data (latest_plex_list.txt and latest_processed_plex_list.txt are the same)"

--- a/bin/gtck_refresh_check_data_incremental.sh
+++ b/bin/gtck_refresh_check_data_incremental.sh
@@ -5,12 +5,6 @@ set -e -o pipefail
 
 # $VERSION = '0';
 
-if [[ -e latest_plex_list.txt ]] && [[ -e latest_combined_file.txt ]] && ! cmp -s latest_plex_list.txt latest_combined_file.txt
-then
-  echo "Run appears to be in progress (contents of latest_plex_list.txt and latest_combined_file.txt differ)"
-  exit 0
-fi
-
 # extract lists of relevant data_object names
 gtck_genplexlist.sh
 


### PR DESCRIPTION
remove top-level attempt at locking - use flock in cronjob invocation instead (gtck_refresh_check_data_incremental.sh)

stricter checks for required files